### PR TITLE
Updated from BFO 1.1 to BFO 2.0 by blindly running BFOConvert with th…

### DIFF
--- a/ontology/bodo-descriptor.owl
+++ b/ontology/bodo-descriptor.owl
@@ -1,35 +1,19 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY bibtexml "http://bibtexml.sf.net/" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY chemoinformatics-algorithms "http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#" >
-]>
- 
-
 <rdf:RDF xmlns="http://semanticscience.org/ontology/bodo.owl#"
      xml:base="http://semanticscience.org/ontology/bodo.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:bibtexml="http://bibtexml.sf.net/"
      xmlns:chemoinformatics-algorithms="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-    <owl:Ontology rdf:about="">
-        <dc:title
-            >Blue Obelisk Descriptor Ontology</dc:title>
-        <dc:creator
-            >Egon Willighagen</dc:creator>
-        <dc:creator
-            >Michel Dumontier</dc:creator>
+    <owl:Ontology rdf:about="http://semanticscience.org/ontology/bodo.owl">
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
+        <dc:creator>Egon Willighagen</dc:creator>
+        <dc:creator>Michel Dumontier</dc:creator>
+        <dc:title>Blue Obelisk Descriptor Ontology</dc:title>
     </owl:Ontology>
     
 
@@ -42,13 +26,48 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:AnnotationProperty rdf:about="&dc;date"/>
-    <owl:AnnotationProperty rdf:about="&bibtexml;entry"/>
-    <owl:AnnotationProperty rdf:about="&dc;title"/>
-    <owl:AnnotationProperty rdf:about="&chemoinformatics-algorithms;description"/>
-    <owl:AnnotationProperty rdf:about="&chemoinformatics-algorithms;definition"/>
-    <owl:AnnotationProperty rdf:about="&dc;contributor"/>
-    <owl:AnnotationProperty rdf:about="&dc;creator"/>
+    
+
+
+    <!-- entry -->
+
+    <owl:AnnotationProperty rdf:about="http://bibtexml.sf.net/entry"/>
+    
+
+
+    <!-- contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor"/>
+    
+
+
+    <!-- creator -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/creator"/>
+    
+
+
+    <!-- date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- title -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
+    
+
+
+    <!-- definition -->
+
+    <owl:AnnotationProperty rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#definition"/>
+    
+
+
+    <!-- description -->
+
+    <owl:AnnotationProperty rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#description"/>
     
 
 
@@ -63,36 +82,33 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ALOGP -->
+    <!-- ALogP -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;ALOGP">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ALOGP">
         <rdfs:label>ALogP</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#tm</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#tm</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Calculates atom additive logP and molar refractivity values as described by Ghose and Crippen
+        <chemoinformatics-algorithms:definition>Calculates atom additive logP and molar refractivity values as described by Ghose and Crippen
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;GHOSE1986&quot;&gt;&lt;/bibtex:cite&gt; and &lt;bibtex:cite ref=&quot;GHOSE1987&quot;&gt;&lt;/bibtex:cite&gt;</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor -->
+    <!-- AtomicDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;AtomicDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BAT95 -->
+    <!-- BAT95 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;BAT95">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BAT95">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Bath, P.A. and Poirette, A.R. and Willet, P. and Allen, F.H.
                 &lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;The Extent of the Relationship between the Graph-Theoretical and the Geometrical Shape
@@ -107,33 +123,29 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BCUT -->
+    <!-- BCUT -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;BCUT">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BCUT">
         <rdfs:label>BCUT</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;hybridDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Eigenvalue based descriptor noted for its utility in chemical diversity
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hybridDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+        <dc:date>2005-01-27</dc:date>
+        <chemoinformatics-algorithms:definition>Eigenvalue based descriptor noted for its utility in chemical diversity
             described by Pearlman et al.
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;PEA99&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:definition>
-        <dc:date>2005-01-27</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BK02 -->
+    <!-- BK02 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;BK02">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
-                &lt;bibtex:author&gt;B&#195;&#182;hm, M. and Klebe, G.&lt;/bibtex:author&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BK02">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+                &lt;bibtex:author&gt;BÃ¶hm, M. and Klebe, G.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Development of New Hydrogen-Bond Descriptors and Their {A}pplication to Comparative Molecular Field Analyses&lt;/bibtex:title&gt;
                 &lt;bibtex:journal&gt;J. Med. Chem.&lt;/bibtex:journal&gt;
                 &lt;bibtex:year&gt;2002&lt;/bibtex:year&gt;
@@ -144,20 +156,19 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor -->
+    <!-- BondDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;BondDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#CHER2003 -->
+    <!-- CHER2003 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;CHER2003">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#CHER2003">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Cherkasov, A.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Inductive Electronegativity Scale. Iterative Calculation of Inductive Partial
                     Charges
@@ -172,29 +183,25 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#CPSA -->
+    <!-- Charged Partial Surface Areas -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;CPSA">
-        <rdfs:label
-            >Charged Partial Surface Areas</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >A variety of descriptors combining surface area and partial charge information</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#CPSA">
+        <rdfs:label>Charged Partial Surface Areas</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2005-05-16</dc:date>
+        <chemoinformatics-algorithms:definition>A variety of descriptors combining surface area and partial charge information</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#DAY01 -->
+    <!-- DAY01 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;DAY01">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:misc xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#DAY01">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:misc xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Daylight&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;SMILES on-line tutorial&lt;/bibtex:title&gt;
                 &lt;bibtex:url&gt;http://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html&lt;/bibtex:url&gt;
@@ -203,18 +210,17 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor -->
+    <!-- Descriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ERTL2000 -->
+    <!-- ERTL2000 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;ERTL2000">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ERTL2000">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Ertl, P. and Rohde, B. and Selzer, P.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Fast Calculation of Molecular Polar Surface Area as a Sum of
                     Fragment-Based Contributions and Its Application to the Prediction of
@@ -231,12 +237,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#GAST2002 -->
+    <!-- GAST2002 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;GAST2002">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#GAST2002">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Aires-de-Sousa, J. and Hemmer, M.C. and Gasteiger, J.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Prediction of 1H NMR Chemical Shifts Using Neural Networks&lt;/bibtex:title&gt;
                 &lt;bibtex:journal&gt;Anal. Chem.&lt;/bibtex:journal&gt;
@@ -250,12 +255,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#GWB98 -->
+    <!-- GWB98 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;GWB98">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#GWB98">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
               &lt;bibtex:author&gt;Gillet, J. and Willett, P. and Bradshaw, J.&lt;/bibtex:author&gt;
               &lt;bibtex:title&gt;Identification of Biological Activity Profiles Using Substructural Analysis and Genetic Algorithms&lt;/bibtex:title&gt;
               &lt;bibtex:journal&gt;J. Chem. Inf. Comput. Sci.&lt;/bibtex:journal&gt;
@@ -267,12 +271,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#KAT96 -->
+    <!-- KAT96 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;KAT96">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#KAT96">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Katritzky, A.R. and Mu, L. and Lobanov, V.S. and Karelson, M.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Correlation of Boiling Points With Molecular Structure. 1. A Training Set of 298 Diverse
                     Organics and a Test Set of 9 Simple Inorganics
@@ -286,12 +289,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#LIU98 -->
+    <!-- LIU98 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;LIU98">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#LIU98">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Liu, S. and Cao, C. and Li, Z.
                 &lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Approach to Estimation and Prediction for Normal
@@ -307,12 +309,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MARSILI -->
+    <!-- MARSILI -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;MARSILI">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MARSILI">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Gasteiger, J.&lt;/bibtex:author&gt;
                 &lt;bibtex:author&gt;Marsili, M.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;
@@ -328,36 +329,32 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor -->
+    <!-- MolecularDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;MolecularDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#NilaComplexity -->
+    <!-- Fragment Complexity -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;NilaComplexity">
-        <rdfs:label
-            >Fragment Complexity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The complexity of a system. The complexity is defined as @cdk.cite{Nilakantan06}</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#NilaComplexity">
+        <rdfs:label>Fragment Complexity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
         <dc:date>2006-8-22</dc:date>
+        <chemoinformatics-algorithms:definition>The complexity of a system. The complexity is defined as @cdk.cite{Nilakantan06}</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PEA99 -->
+    <!-- PEA99 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;PEA99">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PEA99">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Pearlman, R.S. and Smith, K.M.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Metric Validation and the Receptor-Relevant Subspace Concept&lt;/bibtex:title&gt;
                 &lt;bibtex:journal&gt;J. Chem. Inf. Comput. Sci.&lt;/bibtex:journal&gt;
@@ -370,12 +367,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PET92 -->
+    <!-- PET92 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;PET92">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PET92">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Petitjean, M.
                 &lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Applications of the radius-diameter diagram to the classification of topological and
@@ -390,12 +386,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PL96 -->
+    <!-- PL96 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;PL96">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#PL96">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
               &lt;bibtex:author&gt;Patani, G. A. and LaVoie, E. J.&lt;/bibtex:author&gt;
               &lt;bibtex:title&gt;Bioisosterism: A Rational Approach in Drug Design&lt;/bibtex:title&gt;
               &lt;bibtex:journal&gt;Chem. Rev.&lt;/bibtex:journal&gt;
@@ -407,20 +402,19 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ProteinDescriptor -->
+    <!-- ProteinDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;ProteinDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ProteinDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#RAN84 -->
+    <!-- RAN84 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;RAN84">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#RAN84">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Randic, M.
                 &lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;On molecular identification numbers&lt;/bibtex:title&gt;
@@ -433,18 +427,17 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference -->
+    <!-- Reference -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;Reference"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#SALLER -->
+    <!-- SALLER -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;SALLER">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#SALLER">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Gasteiger, J.&lt;/bibtex:author&gt;
                 &lt;bibtex:author&gt;Saller, H.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;
@@ -461,12 +454,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TC00 -->
+    <!-- TC00 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;TC00">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TC00">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
               &lt;bibtex:author&gt;Todeschini, R. and Consonni, V.&lt;/bibtex:author&gt;
               &lt;bibtex:title&gt;Handbook of Molecular Descriptors&lt;/bibtex:title&gt;
               &lt;bibtex:year&gt;2000&lt;/bibtex:year&gt;
@@ -476,12 +468,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TOD98 -->
+    <!-- TOD98 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;TOD98">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TOD98">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Todeschini, R. and Gramatica, P.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;New 3D Molecular Descriptors: The WHIM theory and QAR Applications&lt;/bibtex:title&gt;
                 &lt;bibtex:journal&gt;Persepectives in Drug Discovery and Design&lt;/bibtex:journal&gt;
@@ -492,12 +483,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TRI92 -->
+    <!-- TRI92 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;TRI92">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:book xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#TRI92">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:book xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Trinijastic, N.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Chemical Graph Theory&lt;/bibtex:title&gt;
                 &lt;bibtex:publisher&gt;CRC Press&lt;/bibtex:publisher&gt;
@@ -508,12 +498,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WANG97 -->
+    <!-- WANG97 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;WANG97">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WANG97">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Wang, R., Fu, Y., and Lai, L.&lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;A New Atom-Additive Method for Calculating Partition Coefficients&lt;/bibtex:title&gt;
                 &lt;bibtex:journal&gt;Journal of Chemical Information and Computer
@@ -527,12 +516,11 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WES98 -->
+    <!-- WES98 -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;WES98">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Reference"/>
-        <bibtexml:entry
-            >&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WES98">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Reference"/>
+        <bibtexml:entry>&lt;bibtex:article xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot;&gt;
                 &lt;bibtex:author&gt;Wessel, M.D. and Jurs, P.C. and Tolan, J.W. and Muskal, S.M.
                 &lt;/bibtex:author&gt;
                 &lt;bibtex:title&gt;Prediction of Human Intestinal Absorption of Drug Compounds
@@ -549,154 +537,125 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WHIM -->
+    <!-- WHIM -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;WHIM">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#WHIM">
         <rdfs:label>WHIM</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;hybridDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hybridDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Holistic descriptors described by Todeschini et al
+        <chemoinformatics-algorithms:definition>Holistic descriptors described by Todeschini et al
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;TOD98&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aminoAcidsCount -->
+    <!-- Amino Acid Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;aminoAcidsCount">
-        <rdfs:label
-            >Amino Acid Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;ProteinDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aminoAcidsCount">
+        <rdfs:label>Amino Acid Count</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ProteinDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
         <dc:date>2006-01-15</dc:date>
+        <chemoinformatics-algorithms:definition>The number of amino acids found in the system</chemoinformatics-algorithms:definition>
         <chemoinformatics-algorithms:description></chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The number of amino acids found in the system</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#apol -->
+    <!-- Atomic Polarizabilities -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;apol">
-        <rdfs:label
-            >Atomic Polarizabilities</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The sum of the atomic polarizabilities (including implicit hydrogens).</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#apol">
+        <rdfs:label>Atomic Polarizabilities</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:description
-            >Polarizabilities derive from periodic tables.</chemoinformatics-algorithms:description>
+        <chemoinformatics-algorithms:definition>The sum of the atomic polarizabilities (including implicit hydrogens).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Polarizabilities derive from periodic tables.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aromaticAtomsCount -->
+    <!-- Aromatic Atoms Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;aromaticAtomsCount">
-        <rdfs:label
-            >Aromatic Atoms Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of aromatic atoms of a molecule.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aromaticAtomsCount">
+        <rdfs:label>Aromatic Atoms Count</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The number of aromatic atoms of a molecule.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aromaticBondsCount -->
+    <!-- Aromatic Bonds Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;aromaticBondsCount">
-        <rdfs:label
-            >Aromatic Bonds Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#aromaticBondsCount">
+        <rdfs:label>Aromatic Bonds Count</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of aromatic bonds of a molecule.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of aromatic bonds of a molecule.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomCount -->
+    <!-- Element Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomCount">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomCount">
         <rdfs:label>Element Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of atoms of a certain element type.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of atoms of a certain element type.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomDegree -->
+    <!-- Atomic Degree -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomDegree">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomDegree">
         <rdfs:label>Atomic Degree</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of not-Hs substituents of an atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of not-Hs substituents of an atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomHybridization -->
+    <!-- Atomic Hybridization -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomHybridization">
-        <rdfs:label
-            >Atomic Hybridization</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The hybridization state of an atom.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomHybridization">
+        <rdfs:label>Atomic Hybridization</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The hybridization state of an atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomHybridizationVSEPR -->
+    <!-- Atomic Hybridization VSEPR -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomHybridizationVSEPR">
-        <rdfs:label
-            >Atomic Hybridization VSEPR</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The hybridization state of an atom.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomHybridizationVSEPR">
+        <rdfs:label>Atomic Hybridization VSEPR</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >The calculation find a SIMPLE WAY the molecular geometry for
+        <chemoinformatics-algorithms:definition>The hybridization state of an atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The calculation find a SIMPLE WAY the molecular geometry for
             following from Valence Shell Electron Pair Repulsion or
             VSEPR model and at the same time its hybridization of atoms
             in a molecule.</chemoinformatics-algorithms:description>
@@ -704,35 +663,29 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomValence -->
+    <!-- Atomic Valence -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomValence">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomValence">
         <rdfs:label>Atomic Valence</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The valence of an atom.</chemoinformatics-algorithms:definition>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The valence of an atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomicHardness -->
+    <!-- Inductive atomic hardness -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomicHardness">
-        <rdfs:label
-            >Inductive atomic hardness</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The atomic hardness of a given atom.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomicHardness">
+        <rdfs:label>Inductive atomic hardness</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-04-21</dc:date>
-        <chemoinformatics-algorithms:description
-            >Inductive atomic hardness of an atom in a polyatomic system can be defined
+        <chemoinformatics-algorithms:definition>The atomic hardness of a given atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Inductive atomic hardness of an atom in a polyatomic system can be defined
             as the resistance to a change of the atomic charge.
             This descriptor is described by Cherkasov
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;CHER2003&quot;&gt;&lt;/bibtex:cite&gt;
@@ -741,20 +694,16 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomicSoftness -->
+    <!-- Inductive atomic softness -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;atomicSoftness">
-        <rdfs:label
-            >Inductive atomic softness</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The atomic softness of a given atom.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#atomicSoftness">
+        <rdfs:label>Inductive atomic softness</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-04-21</dc:date>
-        <chemoinformatics-algorithms:description
-            >Inductive atomic softness of an atom in a polyatomic system can be defined
+        <chemoinformatics-algorithms:definition>The atomic softness of a given atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Inductive atomic softness of an atom in a polyatomic system can be defined
             as as charge delocalizing ability.
             This descriptor is described by Cherkasov
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;CHER2003&quot;&gt;&lt;/bibtex:cite&gt;
@@ -763,225 +712,180 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationCharge -->
+    <!-- Moreau-Broto Autocorrelation (charge) descriptors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;autoCorrelationCharge">
-        <rdfs:label
-            >Moreau-Broto Autocorrelation (charge) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The Moreau-Broto autocorrelation descriptors using partial charges</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationCharge">
+        <rdfs:label>Moreau-Broto Autocorrelation (charge) descriptors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-01-15</dc:date>
+        <chemoinformatics-algorithms:definition>The Moreau-Broto autocorrelation descriptors using partial charges</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationMass -->
+    <!-- Moreau-Broto Autocorrelation (mass) descriptors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;autoCorrelationMass">
-        <rdfs:label
-            >Moreau-Broto Autocorrelation (mass) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationMass">
+        <rdfs:label>Moreau-Broto Autocorrelation (mass) descriptors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-01-15</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The Moreau-Broto autocorrelation descriptors using atomic weight</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The Moreau-Broto autocorrelation descriptors using atomic weight</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationPolarizability -->
+    <!-- Moreau-Broto Autocorrelation (polarizability) descriptors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;autoCorrelationPolarizability">
-        <rdfs:label
-            >Moreau-Broto Autocorrelation (polarizability) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The Moreau-Broto autocorrelation descriptors using polarizability</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#autoCorrelationPolarizability">
+        <rdfs:label>Moreau-Broto Autocorrelation (polarizability) descriptors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#fm</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-01-15</dc:date>
+        <chemoinformatics-algorithms:definition>The Moreau-Broto autocorrelation descriptors using polarizability</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondCount -->
+    <!-- Bond Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondCount">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondCount">
         <rdfs:label>Bond Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of bonds of a certain bond order.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of bonds of a certain bond order.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialPiCharge -->
+    <!-- Bond Partial Pi Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondPartialPiCharge">
-        <rdfs:label
-            >Bond Partial Pi Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;BondDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialPiCharge">
+        <rdfs:label>Bond Partial Pi Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >The difference the
+        <chemoinformatics-algorithms:definition>bond-pi Partial charge of a bond.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The difference the
             Partial Pi Charge on atoms A and B of a bond. Based in
             Gasteiger Charge.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >bond-pi Partial charge of a bond.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialSigmaCharge -->
+    <!-- Bond Partial Sigma Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondPartialSigmaCharge">
-        <rdfs:label
-            >Bond Partial Sigma Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;BondDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialSigmaCharge">
+        <rdfs:label>Bond Partial Sigma Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:definition
-            >bond-sigma Partial charge of a
+        <chemoinformatics-algorithms:definition>bond-sigma Partial charge of a
             bond.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >The difference the
+        <chemoinformatics-algorithms:description>The difference the
             Partial Sigma Charge on atoms A and B of a bond. Based in
             Gasteiger Charge.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialTCharge -->
+    <!-- Bond Partial Total Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondPartialTCharge">
-        <rdfs:label
-            >Bond Partial Total Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;BondDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >bond-total Partial charge of a
-            bond.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondPartialTCharge">
+        <rdfs:label>Bond Partial Total Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >The difference the
+        <chemoinformatics-algorithms:definition>bond-total Partial charge of a
+            bond.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The difference the
             Partial Total Charge on atoms A and B of a bond. Based in
             Gasteiger Charge.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondSigmaElectronegativity -->
+    <!-- Bond Sigma Electronegativity -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondSigmaElectronegativity">
-        <rdfs:label
-            >Bond Sigma Electronegativity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;BondDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondSigmaElectronegativity">
+        <rdfs:label>Bond Sigma Electronegativity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#BondDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >The difference the
+        <chemoinformatics-algorithms:definition>of bond-Polarizability of a bond.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The difference the
             Sigma electronegativity on atoms A and B of a bond.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >of bond-Polarizability of a bond.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondsToAtom -->
+    <!-- Bonds to Atom -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bondsToAtom">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bondsToAtom">
         <rdfs:label>Bonds to Atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of bonds on the shortest path between two atoms.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of bonds on the shortest path between two atoms.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bpol -->
+    <!-- Bond Polarizabilities -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;bpol">
-        <rdfs:label
-            >Bond Polarizabilities</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Polarizabilities derive from periodic tables.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The sum of the absolute value of the difference between atomic
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#bpol">
+        <rdfs:label>Bond Polarizabilities</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The sum of the absolute value of the difference between atomic
             polarizabilities of all bonded atoms in the molecule (including implicit hydrogens).</chemoinformatics-algorithms:definition>
-        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:description>Polarizabilities derive from periodic tables.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#carbonTypes -->
+    <!-- Carbon Types -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;carbonTypes">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#carbonTypes">
         <rdfs:label>Carbon Types</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-09-26</dc:date>
-        <chemoinformatics-algorithms:description
-            >This is a port of the ADAPT CTYPES routine and is a count of
+        <chemoinformatics-algorithms:definition>Characterizes the carbon connectivity in terms of hybridization</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>This is a port of the ADAPT CTYPES routine and is a count of
             carbon atom in different hybridization states and environments</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >Characterizes the carbon connectivity in terms of hybridization</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0C -->
+    <!-- Carbon connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi0C">
-        <rdfs:label
-            >Carbon connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The carbon connectivity index (order 0).</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0C">
+        <rdfs:label>Carbon connectivity index (order 0)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:description
-            >While the atomic connectivity is calculated as the sum of
+        <chemoinformatics-algorithms:definition>The carbon connectivity index (order 0).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>While the atomic connectivity is calculated as the sum of
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mfrac&gt;
                     &lt;mi&gt;1&lt;/mi&gt;
@@ -1002,17 +906,16 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0v -->
+    <!-- Valence connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi0v">
-        <rdfs:label
-            >Valence connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Let
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0v">
+        <rdfs:label>Valence connectivity index (order 0)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>atomic valence connectivity index (order 0).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Let
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mrow&gt;
                     &lt;msub&gt;
@@ -1114,27 +1017,20 @@
                 &lt;/msub&gt;
             &lt;/mrow&gt;
             greather than 0.</chemoinformatics-algorithms:description>
-        <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >atomic valence connectivity index (order 0).</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0vC -->
+    <!-- Valence carbon connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi0vC">
-        <rdfs:label
-            >Valence carbon connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi0vC">
+        <rdfs:label>Valence carbon connectivity index (order 0)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >carbon valence connectivity index (order 0).</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Let
+        <chemoinformatics-algorithms:definition>carbon valence connectivity index (order 0).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Let
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mrow&gt;
                     &lt;msub&gt;
@@ -1248,19 +1144,16 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1C -->
+    <!-- Carbon connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi1C">
-        <rdfs:label
-            >Carbon connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >carbon connectivity index (order 1).</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >While the atomic connectivity is calculated as the sum of
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1C">
+        <rdfs:label>Carbon connectivity index (order 1)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>carbon connectivity index (order 1).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>While the atomic connectivity is calculated as the sum of
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mfrac&gt;
                     &lt;mi&gt;1&lt;/mi&gt;
@@ -1289,22 +1182,20 @@
             &lt;/mrow&gt;
             over all bonds between heavy atoms i and j, the carbon connectivity index
             takes into account only bonds between carbon atoms.</chemoinformatics-algorithms:description>
-        <dc:date>2004-11-26</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1v -->
+    <!-- Valence connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi1v">
-        <rdfs:label
-            >Valence connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Let
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1v">
+        <rdfs:label>Valence connectivity index (order 1)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>atomic valence connectivity index (order 1).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Let
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mrow&gt;
                     &lt;msub&gt;
@@ -1405,27 +1296,20 @@
                 &lt;/mfrac&gt;
             &lt;/mrow&gt;
             over all bonds between heavy atoms i and j.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >atomic valence connectivity index (order 1).</chemoinformatics-algorithms:definition>
-        <dc:date>2004-11-26</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1vC -->
+    <!-- Valence carbon connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chi1vC">
-        <rdfs:label
-            >Valence carbon connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chi1vC">
+        <rdfs:label>Valence carbon connectivity index (order 1)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >carbon valence connectivity index (order 1).</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Let
+        <chemoinformatics-algorithms:definition>carbon valence connectivity index (order 1).</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Let
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mrow&gt;
                     &lt;msub&gt;
@@ -1531,142 +1415,117 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiChain -->
+    <!-- Chi Chain Indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chiChain">
-        <rdfs:label
-            >Chi Chain Indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Evaluates the Kier &amp;amp; Hall Chi chain indices of orders 3,4,5 and 6</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiChain">
+        <rdfs:label>Chi Chain Indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-11-12</dc:date>
-        <chemoinformatics-algorithms:description
-            >Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
+        <chemoinformatics-algorithms:definition>Evaluates the Kier &amp;amp; Hall Chi chain indices of orders 3,4,5 and 6</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiCluster -->
+    <!-- Chi Cluster Indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chiCluster">
-        <rdfs:label
-            >Chi Cluster Indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >Evaluates the Kier &amp;amp; Hall Chi cluster indices of orders 3,4,5,6 and 7</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiCluster">
+        <rdfs:label>Chi Cluster Indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-11-13</dc:date>
+        <chemoinformatics-algorithms:definition>Evaluates the Kier &amp;amp; Hall Chi cluster indices of orders 3,4,5,6 and 7</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiPath -->
+    <!-- Chi Path Indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chiPath">
-        <rdfs:label
-            >Chi Path Indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Evaluates the Kier &amp;amp; Hall Chi path indices of orders 0,1,2,3,4,5,6 and 7</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiPath">
+        <rdfs:label>Chi Path Indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-11-12</dc:date>
+        <chemoinformatics-algorithms:definition>Evaluates the Kier &amp;amp; Hall Chi path indices of orders 0,1,2,3,4,5,6 and 7</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiPathCluster -->
+    <!-- Chi Path-Cluster Indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;chiPathCluster">
-        <rdfs:label
-            >Chi Path-Cluster Indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Evaluates the Kier &amp;amp; Hall Chi path cluster indices of orders 4,5 and 6</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chiPathCluster">
+        <rdfs:label>Chi Path-Cluster Indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-11-13</dc:date>
-        <chemoinformatics-algorithms:description
-            >Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
+        <chemoinformatics-algorithms:definition>Evaluates the Kier &amp;amp; Hall Chi path cluster indices of orders 4,5 and 6</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Both the simple and valence versions of this descriptor are evaluated</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor -->
+    <!-- constitutionalDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;constitutionalDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#covalentRadius -->
+    <!-- Covalent Radius -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;covalentRadius">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#covalentRadius">
         <rdfs:label>Covalent Radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The covalent radius of a given atom.</chemoinformatics-algorithms:definition>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
+        <chemoinformatics-algorithms:definition>The covalent radius of a given atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#distanceToAtom -->
+    <!-- Distance to Atom -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;distanceToAtom">
-        <rdfs:label
-            >Distance to Atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#distanceToAtom">
+        <rdfs:label>Distance to Atom</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The 3D distance between two atoms.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The 3D distance between two atoms.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#eccentricConnectivityIndex -->
+    <!-- Eccentric Connectivity Index -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;eccentricConnectivityIndex">
-        <rdfs:label
-            >Eccentric Connectivity Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#eccentricConnectivityIndex">
+        <rdfs:label>Eccentric Connectivity Index</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2005-03-19</dc:date>
-        <chemoinformatics-algorithms:definition
-            >A topological descriptor combining distance and adjacency information.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >
+        <chemoinformatics-algorithms:definition>A topological descriptor combining distance and adjacency information.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>
 
             The eccentric connectivity index for a hydrogen supressed molecular graph is given by the
             expression
 
             &lt;math xmlns=&quot;http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#&quot; display=&quot;block&quot; overflow=&quot;scroll&quot;&gt;
                 &lt;msup&gt;
-                    &lt;mi&gt;&#206;&#190;&lt;/mi&gt;
+                    &lt;mi&gt;Î¾&lt;/mi&gt;
                     &lt;mi&gt;c&lt;/mi&gt;
 
                 &lt;/msup&gt;
                 &lt;mo&gt;=&lt;/mo&gt;
                 &lt;munder&gt;
-                    &lt;mo&gt;&#226;&#710;&#8216;&lt;/mo&gt;
+                    &lt;mo&gt;âˆ‘&lt;/mo&gt;
                     &lt;mrow&gt;
                         &lt;mi&gt;i&lt;/mi&gt;
                         &lt;mo&gt;=&lt;/mo&gt;
@@ -1676,13 +1535,13 @@
                 &lt;/munder&gt;
                 &lt;mi&gt;n&lt;/mi&gt;
                 &lt;mi&gt;E&lt;/mi&gt;
-                &lt;mo&gt;&#226;?&#161;&lt;/mo&gt;
+                &lt;mo&gt;â?¡&lt;/mo&gt;
                 &lt;mfenced&gt;
 
                     &lt;mi&gt;i&lt;/mi&gt;
                 &lt;/mfenced&gt;
                 &lt;mi&gt;V&lt;/mi&gt;
-                &lt;mo&gt;&#226;?&#161;&lt;/mo&gt;
+                &lt;mo&gt;â?¡&lt;/mo&gt;
                 &lt;mfenced&gt;
                     &lt;mi&gt;i&lt;/mi&gt;
                 &lt;/mfenced&gt;
@@ -1701,292 +1560,235 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#effectivePolarizability -->
+    <!-- Effective Polarizability -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;effectivePolarizability">
-        <rdfs:label
-            >Effective Polarizability</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#effectivePolarizability">
+        <rdfs:label>Effective Polarizability</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:description
-            >Polarizabilities are assigned to the heavy atom by Polarizability class.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The effective polarizability of a given heavy atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The effective polarizability of a given heavy atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Polarizabilities are assigned to the heavy atom by Polarizability class.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor -->
+    <!-- electronicDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;electronicDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor -->
+    <!-- geometricalDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;geometricalDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#gravitationalIndex -->
+    <!-- Gravitational Index -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;gravitationalIndex">
-        <rdfs:label
-            >Gravitational Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >This descriptor is described by Katritzky et al.
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#gravitationalIndex">
+        <rdfs:label>Gravitational Index</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+        <dc:date>2004-11-24</dc:date>
+        <chemoinformatics-algorithms:definition>Descriptor characterizing the mass distribution of the molecule.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>This descriptor is described by Katritzky et al.
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;KAT96&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <dc:date>2004-11-24</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Descriptor characterizing the mass distribution of the molecule.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#gravitationalIndex_SquareAndCubeRoots -->
+    <!-- Gravitational Index (Square and Cube Roots) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;gravitationalIndex_SquareAndCubeRoots">
-        <rdfs:label
-            >Gravitational Index (Square and Cube Roots)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#gravitationalIndex_SquareAndCubeRoots">
+        <rdfs:label>Gravitational Index (Square and Cube Roots)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2004-11-25</dc:date>
-        <chemoinformatics-algorithms:description
-            >This descriptor is described by Wessel et al.
+        <chemoinformatics-algorithms:definition>Descriptor characterizing the mass distribution of the molecule as the square
+            or cube root of the gravitational index.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>This descriptor is described by Wessel et al.
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;WES98&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >Descriptor characterizing the mass distribution of the molecule as the square
-            or cube root of the gravitational index.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondAcceptorsBoehmKlebe -->
+    <!-- Acceptor Field Atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondAcceptorsBoehmKlebe">
-        <rdfs:label
-            >Acceptor Field Atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Force field based definition of hydrogen bond acceptors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondAcceptorsBoehmKlebe">
+        <rdfs:label>Acceptor Field Atoms (Boehm,Klebe)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
+        <dc:date>2006-09-08</dc:date>
+        <chemoinformatics-algorithms:definition>The number of acceptor field atoms for a carbonyl oxygen probe.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Force field based definition of hydrogen bond acceptors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;
         This rule covers nitril, carbonyl, ether, and amin nitrogens.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The number of acceptor field atoms for a carbonyl oxygen probe.</chemoinformatics-algorithms:definition>
-        <dc:date>2006-09-08</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondAcceptorsDonorsBoehmKlebe -->
+    <!-- Acceptors or Donors Field Atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondAcceptorsDonorsBoehmKlebe">
-        <rdfs:label
-            >Acceptors or Donors Field Atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of acceptor/donor field atoms for a carbonyl oxygen or amino hydrogen probe.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondAcceptorsDonorsBoehmKlebe">
+        <rdfs:label>Acceptors or Donors Field Atoms (Boehm,Klebe)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
         <dc:date>2006-09-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >Force field based definition of hydrogen bond acceptors or donors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;.
+        <chemoinformatics-algorithms:definition>The number of acceptor/donor field atoms for a carbonyl oxygen or amino hydrogen probe.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Force field based definition of hydrogen bond acceptors or donors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;.
         This rule covers amino and hydroxy groups.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonors -->
+    <!-- Hydrogen Bond Donors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondDonors">
-        <rdfs:label
-            >Hydrogen Bond Donors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of hydrogen bond donors.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonors">
+        <rdfs:label>Hydrogen Bond Donors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The number of hydrogen bond donors.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonorsBoehmKlebe -->
+    <!-- Donor Field Atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondDonorsBoehmKlebe">
-        <rdfs:label
-            >Donor Field Atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of donor field atoms for an amino hydrogen probe.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Force field based definition of hydrogen bond donors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;.
-        This rule covers amino groups, chloro, bromo and iodo atoms &lt;bibtex:cite ref=&quot;PL96&quot;&gt;&lt;/bibtex:cite&gt;.</chemoinformatics-algorithms:description>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonorsBoehmKlebe">
+        <rdfs:label>Donor Field Atoms (Boehm,Klebe)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#jkw</dc:contributor>
         <dc:date>2006-09-08</dc:date>
+        <chemoinformatics-algorithms:definition>The number of donor field atoms for an amino hydrogen probe.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Force field based definition of hydrogen bond donors &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;BK02&quot;&gt;&lt;/bibtex:cite&gt;.
+        This rule covers amino groups, chloro, bromo and iodo atoms &lt;bibtex:cite ref=&quot;PL96&quot;&gt;&lt;/bibtex:cite&gt;.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonorsDaylight -->
+    <!-- Hydrogen Bond Donors (Daylight) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondDonorsDaylight">
-        <rdfs:label
-            >Hydrogen Bond Donors (Daylight)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondDonorsDaylight">
+        <rdfs:label>Hydrogen Bond Donors (Daylight)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
-        <chemoinformatics-algorithms:description
-            >As defined by Daylight website, &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;DAY01&quot;&gt;&lt;/bibtex:cite&gt;, a H-bond acceptor
+        <chemoinformatics-algorithms:definition>the number of hydrogen bond donors.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>As defined by Daylight website, &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;DAY01&quot;&gt;&lt;/bibtex:cite&gt;, a H-bond acceptor
 	must have an N-H bond, an O-H bond, or a F-H bond</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >the number of hydrogen bond donors.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondacceptors -->
+    <!-- Hydrogen Bond Acceptors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondacceptors">
-        <rdfs:label
-            >Hydrogen Bond Acceptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of hydrogen bond acceptors.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondacceptors">
+        <rdfs:label>Hydrogen Bond Acceptors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The number of hydrogen bond acceptors.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondacceptorsDaylight -->
+    <!-- Hydrogen Bond Acceptors (Daylight) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hBondacceptorsDaylight">
-        <rdfs:label
-            >Hydrogen Bond Acceptors (Daylight)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >As defined by Daylight website, &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;DAY01&quot;&gt;&lt;/bibtex:cite&gt;, a H-bond acceptor is a heteroatom with no positive charge, note that negatively 
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hBondacceptorsDaylight">
+        <rdfs:label>Hydrogen Bond Acceptors (Daylight)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>the number of hydrogen bond acceptors.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>As defined by Daylight website, &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;DAY01&quot;&gt;&lt;/bibtex:cite&gt;, a H-bond acceptor is a heteroatom with no positive charge, note that negatively 
         charged oxygen or sulphur are included. Excluded are halogens, including F, 
         heteroaromatic oxygen, sulphur and pyrrole N. Higher oxidation levels of N,P,S are excluded.
-        Note P(III) is currently included. Zeneca&#39;s work would imply that (O=S=O) shoud also be excluded.</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >the number of hydrogen bond acceptors.</chemoinformatics-algorithms:definition>
-        <dc:date>2004-11-26</dc:date>
+        Note P(III) is currently included. Zeneca&apos;s work would imply that (O=S=O) shoud also be excluded.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hybridDescriptor -->
+    <!-- hybridDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;hybridDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#hybridDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ip -->
+    <!-- Ionization Potential -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;ip">
-        <rdfs:label
-            >Ionization Potential</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mr</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The ionization potential.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >It should be noted that the descriptor values are obtained using a predictive model
-            and are not calculated directly from the structure</chemoinformatics-algorithms:description>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ip">
+        <rdfs:label>Ionization Potential</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mr</dc:contributor>
         <dc:date>2006-01-15</dc:date>
+        <chemoinformatics-algorithms:definition>The ionization potential.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>It should be noted that the descriptor values are obtained using a predictive model
+            and are not calculated directly from the structure</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#isProtonInAromaticSystem -->
+    <!-- Proton belonging to an aromatic system -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;isProtonInAromaticSystem">
-        <rdfs:label
-            >Proton belonging to an aromatic system</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#isProtonInAromaticSystem">
+        <rdfs:label>Proton belonging to an aromatic system</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:definition
-            >1 if the protons is directly bonded to an aromatic system, 2 if the distance between aromatic system and proton is 2 bonds, and 0 for other positions.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>1 if the protons is directly bonded to an aromatic system, 2 if the distance between aromatic system and proton is 2 bonds, and 0 for other positions.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#isProtonInConjugatedPiSystem -->
+    <!-- Proton belonging to a pi-system -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;isProtonInConjugatedPiSystem">
-        <rdfs:label
-            >Proton belonging to a pi-system</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >true if the protons is directly bonded to a pi system.</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#isProtonInConjugatedPiSystem">
+        <rdfs:label>Proton belonging to a pi-system</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
+        <chemoinformatics-algorithms:definition>true if the protons is directly bonded to a pi system.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#kierHallSmarts -->
+    <!-- Kier &amp; Hall SMARTS -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;kierHallSmarts">
-        <rdfs:label
-            >Kier &amp; Hall SMARTS</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#kierHallSmarts">
+        <rdfs:label>Kier &amp; Hall SMARTS</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-09-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Counts the number of occurrences of the E-state fragments</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Traditionally, the E-state indices are obtained by identifying a set of
+        <chemoinformatics-algorithms:definition>Counts the number of occurrences of the E-state fragments</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Traditionally, the E-state indices are obtained by identifying a set of
             fragments and then evaluating the E-state index from them. However it has
             been shown by Butina (Molecules, 2004, 9, 1004-1009) that the frequency
             of occurrence of the fragments can lead to QSAR models that perform as well
@@ -1996,19 +1798,16 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#kierValues -->
+    <!-- Kier and Hall kappa molecular shape indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;kierValues">
-        <rdfs:label
-            >Kier and Hall kappa molecular shape indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Kier and Hall kappa molecular shape indices.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Kier and Hall kappa molecular shape indices compare the molecular graph with minimal and maximal molecular
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#kierValues">
+        <rdfs:label>Kier and Hall kappa molecular shape indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>Kier and Hall kappa molecular shape indices.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Kier and Hall kappa molecular shape indices compare the molecular graph with minimal and maximal molecular
             graphs.
             First kappa shape index is given by
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
@@ -2145,232 +1944,189 @@
             hydrogen
             suppressed graph. Also, let p2 denote the number of paths of length 2 and let p3 denote the number of paths
             of length 3</chemoinformatics-algorithms:description>
-        <dc:date>2004-11-26</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#largestChain -->
+    <!-- Largest Chain -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;largestChain">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#largestChain">
         <rdfs:label>Largest Chain</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
-        <chemoinformatics-algorithms:description></chemoinformatics-algorithms:description>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of atoms in the largest chain</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of atoms in the largest chain</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description></chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#largestPiSystem -->
+    <!-- Largest Pi Chain -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;largestPiSystem">
-        <rdfs:label
-            >Largest Pi Chain</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
-        <chemoinformatics-algorithms:description></chemoinformatics-algorithms:description>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#largestPiSystem">
+        <rdfs:label>Largest Pi Chain</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of atoms in the largest pi chain</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of atoms in the largest pi chain</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description></chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#lengthOverBreadth -->
+    <!-- Length Over Breadth -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;lengthOverBreadth">
-        <rdfs:label
-            >Length Over Breadth</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >The descriptor has two values
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#lengthOverBreadth">
+        <rdfs:label>Length Over Breadth</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+        <dc:date>2006-09-26</dc:date>
+        <chemoinformatics-algorithms:definition>Calculates the ratio of length to breadth.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The descriptor has two values
             indicating the maximum and minimumn value of LoB. Note that this method does not
             perform any orientation.</chemoinformatics-algorithms:description>
-        <dc:date>2006-09-26</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Calculates the ratio of length to breadth.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#lipinskifailures -->
+    <!-- Lipinski&apos;s Rule of Five -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;lipinskifailures">
-        <rdfs:label
-            >Lipinski&#39;s Rule of Five</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#lipinskifailures">
+        <rdfs:label>Lipinski&apos;s Rule of Five</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:description
-            >The Rule of 5 got its name from the cutoff values for each of the four parameters that define the potential of a drug candidate for good absorption: all of these values are close to five or a multiple of five.
+        <chemoinformatics-algorithms:definition>The number failures of the Lipinski&apos;s Rule Of Five.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The Rule of 5 got its name from the cutoff values for each of the four parameters that define the potential of a drug candidate for good absorption: all of these values are close to five or a multiple of five.
             The original definition, given by Christopher A. Lipinski, says that poor absorption (or permeation) is more likely when the molecule has:
 * more than 5 H-bond donors 
 * more than 10 H-bond acceptors
 * molecular weight over 500 Dalton
 * LogP is over 5</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The number failures of the Lipinski&#39;s Rule Of Five.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#longestAliphaticChain -->
+    <!-- Longest Aliphatic Chain -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;longestAliphaticChain">
-        <rdfs:label
-            >Longest Aliphatic Chain</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The number of atoms in the longest aliphatic chain</chemoinformatics-algorithms:definition>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#longestAliphaticChain">
+        <rdfs:label>Longest Aliphatic Chain</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#chhoppe</dc:contributor>
         <dc:date>2005-02-07</dc:date>
+        <chemoinformatics-algorithms:definition>The number of atoms in the longest aliphatic chain</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mde -->
+    <!-- Molecular Distance Edge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;mde">
-        <rdfs:label
-            >Molecular Distance Edge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mde">
+        <rdfs:label>Molecular Distance Edge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-09-18</dc:date>
-        <chemoinformatics-algorithms:description
-            >For a description of the methodology see
+        <chemoinformatics-algorithms:definition>Evaluate molecular distance edge descriptors for C, N and O</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>For a description of the methodology see
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;LIU98&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >Evaluate molecular distance edge descriptors for C, N and O</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#momentOfInertia -->
+    <!-- Moments of Inertia -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;momentOfInertia">
-        <rdfs:label
-            >Moments of Inertia</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#momentOfInertia">
+        <rdfs:label>Moments of Inertia</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The principal moments of inertia and ratios
+        <chemoinformatics-algorithms:definition>The principal moments of inertia and ratios
             of the principal moments. Als calculates the radius of gyration.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialPiCharge -->
+    <!-- Partial Pi Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;partialPiCharge">
-        <rdfs:label
-            >Partial Pi Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Calculation is based on Gasteiger H.Saller (PEPE)
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialPiCharge">
+        <rdfs:label>Partial Pi Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+        <dc:date>2006-05-08</dc:date>
+        <chemoinformatics-algorithms:definition>pi partial charges in pi-bonded systems of an heavy atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Calculation is based on Gasteiger H.Saller (PEPE)
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;SALLER&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >pi partial charges in pi-bonded systems of an heavy atom.</chemoinformatics-algorithms:definition>
-        <dc:date>2006-05-08</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialSigmaCharge -->
+    <!-- Partial Pi Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;partialSigmaCharge">
-        <rdfs:label
-            >Partial Pi Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialSigmaCharge">
+        <rdfs:label>Partial Pi Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:description
-            >Calculation is based on Gasteiger Marsili (PEOE)
+        <chemoinformatics-algorithms:definition>sigma partial charges in
+            sigma-bonded systems (PEOE) of an heavy atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Calculation is based on Gasteiger Marsili (PEOE)
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;MARSILI&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >sigma partial charges in
-            sigma-bonded systems (PEOE) of an heavy atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialTChargeMMFF94 -->
+    <!-- Partial Total Charge (MMFF94) -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;partialTChargeMMFF94">
-        <rdfs:label
-            >Partial Total Charge (MMFF94)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >Calculation is based on MMFF94.</chemoinformatics-algorithms:description>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#partialTChargeMMFF94">
+        <rdfs:label>Partial Total Charge (MMFF94)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
         <dc:date>2006-05-08</dc:date>
-        <chemoinformatics-algorithms:definition
-            >total partial charges of an heavy
+        <chemoinformatics-algorithms:definition>total partial charges of an heavy
             atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Calculation is based on MMFF94.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#period -->
+    <!-- Period of an atom -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;period">
-        <rdfs:label
-            >Period of an atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#period">
+        <rdfs:label>Period of an atom</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The period in the periodic table of an atom belonging to an atom container</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The period in the periodic table of an atom belonging to an atom container</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#petitjeanNumber -->
+    <!-- Petitjean Number -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;petitjeanNumber">
-        <rdfs:label
-            >Petitjean Number</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#petitjeanNumber">
+        <rdfs:label>Petitjean Number</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:description
-            >According to the Petitjean definition, the eccentricity of a vertex corresponds to the
+        <chemoinformatics-algorithms:definition>The Petitjean Number of a molecule.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>According to the Petitjean definition, the eccentricity of a vertex corresponds to the
             distance from that vertex to the most remote vertex in the graph. The distance
             is obtained from the distance matrix as the count of edges between the two vertices.
             If
@@ -2404,59 +2160,48 @@
                 &lt;/mfrac&gt;
             &lt;/mrow&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The Petitjean Number of a molecule.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#petitjeanShapeIndex -->
+    <!-- Petitjean Shape Indices -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;petitjeanShapeIndex">
-        <rdfs:label
-            >Petitjean Shape Indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#petitjeanShapeIndex">
+        <rdfs:label>Petitjean Shape Indices</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-01-15</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The topological and geometric shape indices described Petitjean and Bath et al.
+        <chemoinformatics-algorithms:definition>The topological and geometric shape indices described Petitjean and Bath et al.
             respectively. Both measure the anisotropy in a molecule.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#piContact -->
+    <!-- Pi-contact of two atoms -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;piContact">
-        <rdfs:label
-            >Pi-contact of two atoms</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#piContact">
+        <rdfs:label>Pi-contact of two atoms</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >check if two atoms have pi-contact (this is true when there is one and
+        <chemoinformatics-algorithms:definition>check if two atoms have pi-contact (this is true when there is one and
             the same conjugated pi-system which contains both atoms, or directly linked neighboors of the atoms).</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#piElectronegativity -->
+    <!-- Pi Electronegativity -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;piElectronegativity">
-        <rdfs:label
-            >Pi Electronegativity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The pi electronegativity for a given atom.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Pi electronegativity is given by
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#piElectronegativity">
+        <rdfs:label>Pi Electronegativity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mrc</dc:contributor>
+        <dc:date>2006-05-08</dc:date>
+        <chemoinformatics-algorithms:definition>The pi electronegativity for a given atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Pi electronegativity is given by
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mi&gt;X&lt;/mi&gt;
                 &lt;mo&gt;=&lt;/mo&gt;
@@ -2479,49 +2224,39 @@
             &lt;/mrow&gt;
             , where a, b and c are Gasteiger Marsili parameters, and q
             is the sigma charge.</chemoinformatics-algorithms:description>
-        <dc:date>2006-05-08</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#protonPartialCharge -->
+    <!-- Proton Total Partial Charge -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;protonPartialCharge">
-        <rdfs:label
-            >Proton Total Partial Charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#protonPartialCharge">
+        <rdfs:label>Proton Total Partial Charge</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:description
-            >Calculation is based on Gasteiger Marsili (PEOE)</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >partial charges of an heavy atom and its protons.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>partial charges of an heavy atom and its protons.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Calculation is based on Gasteiger Marsili (PEOE)</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rdfProtonCalculatedValues -->
+    <!-- RDF Proton Descriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;rdfProtonCalculatedValues">
-        <rdfs:label
-            >RDF Proton Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;geometricalDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rdfProtonCalculatedValues">
+        <rdfs:label>RDF Proton Descriptor</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#geometricalDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:definition
-            >Calculation of RDF proton descriptor based on
+        <chemoinformatics-algorithms:definition>Calculation of RDF proton descriptor based on
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;GAST2002&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >A given proton is represented by 5 different descriptors.
+        <chemoinformatics-algorithms:description>A given proton is represented by 5 different descriptors.
             The first one has the form
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;apply&gt;
@@ -2777,55 +2512,45 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ringCount -->
+    <!-- Ring Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;ringCount">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ringCount">
         <rdfs:label>Ring Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
         <dc:date>2009-07-23</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The number of rings in the molecules.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The number of rings in the molecules.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rotatableBondsCount -->
+    <!-- Rotatable Bonds Count -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;rotatableBondsCount">
-        <rdfs:label
-            >Rotatable Bonds Count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:description
-            >The number of rotatable bonds is given by the SMARTS specified by Daylight on
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rotatableBondsCount">
+        <rdfs:label>Rotatable Bonds Count</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2005-02-07</dc:date>
+        <chemoinformatics-algorithms:definition>The number of rotatable bonds on a molecule.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The number of rotatable bonds is given by the SMARTS specified by Daylight on
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;DAY01&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >The number of rotatable bonds on a molecule.</chemoinformatics-algorithms:definition>
-        <dc:date>2005-02-07</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#sigmaElectronegativity -->
+    <!-- Sigma Electronegativity -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;sigmaElectronegativity">
-        <rdfs:label
-            >Sigma Electronegativity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#sigmaElectronegativity">
+        <rdfs:label>Sigma Electronegativity</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-02-07</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The sigma electronegativity for a given atom.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >Sigma electronegativity is given by
+        <chemoinformatics-algorithms:definition>The sigma electronegativity for a given atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Sigma electronegativity is given by
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mi&gt;X&lt;/mi&gt;
                 &lt;mo&gt;=&lt;/mo&gt;
@@ -2852,68 +2577,57 @@
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#taeAminoAcid -->
+    <!-- TAE RECON descriptors for amino acid sequences -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;taeAminoAcid">
-        <rdfs:label
-            >TAE RECON descriptors for amino acid sequences</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;ProteinDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#taeAminoAcid">
+        <rdfs:label>TAE RECON descriptors for amino acid sequences</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#ProteinDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-08-23</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The TAE RECON descriptors for amino acid sequences. Uses precalculated quantum mechanical
+        <chemoinformatics-algorithms:definition>The TAE RECON descriptors for amino acid sequences. Uses precalculated quantum mechanical
             parameters to generate a set of 147 descriptors for a given sequence</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor -->
+    <!-- topologicalDescriptor -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;topologicalDescriptor">
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;Descriptor"/>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor">
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#Descriptor"/>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#tpsa -->
+    <!-- Topological Polar Surface Area -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;tpsa">
-        <rdfs:label
-            >Topological Polar Surface Area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;electronicDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Calculation of topological polar surface area based on fragment
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#tpsa">
+        <rdfs:label>Topological Polar Surface Area</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#electronicDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2005-01-27</dc:date>
+        <chemoinformatics-algorithms:definition>Calculation of topological polar surface area based on fragment
             contributions
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;ERTL2000&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:definition>
-        <dc:date>2005-01-27</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#vAdjMa -->
+    <!-- Vertex adjacency information magnitude -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;vAdjMa">
-        <rdfs:label
-            >Vertex adjacency information magnitude</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The vertex adjacency information of a molecule.</chemoinformatics-algorithms:definition>
-        <chemoinformatics-algorithms:description
-            >The values is given by
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#vAdjMa">
+        <rdfs:label>Vertex adjacency information magnitude</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The vertex adjacency information of a molecule.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>The values is given by
             &lt;mrow xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;
                 &lt;mn&gt;1&lt;/mn&gt;
                 &lt;mo&gt;+&lt;/mo&gt;
@@ -2925,117 +2639,96 @@
             ,
             where m is the number of heavy-heavy bonds.
             If m is zero, then zero is returned.</chemoinformatics-algorithms:description>
-        <dc:date>2004-11-26</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#vdwradius -->
+    <!-- Van der Waals radius -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;vdwradius">
-        <rdfs:label
-            >Van der Waals radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;AtomicDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#vdwradius">
+        <rdfs:label>Van der Waals radius</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#AtomicDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The VdW radius of a given atom.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The VdW radius of a given atom.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#weight -->
+    <!-- Molecular Weight -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;weight">
-        <rdfs:label
-            >Molecular Weight</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The weight of atoms of a certain element type.
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#weight">
+        <rdfs:label>Molecular Weight</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <dc:date>2005-01-27</dc:date>
+        <chemoinformatics-algorithms:definition>The weight of atoms of a certain element type.
             If no element is specified, the returned value is the Molecular Weight</chemoinformatics-algorithms:definition>
-        <dc:date>2005-01-27</dc:date>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#weightedPath -->
+    <!-- Weighted path descriptors -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;weightedPath">
-        <rdfs:label
-            >Weighted path descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#weightedPath">
+        <rdfs:label>Weighted path descriptors</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#rguha</dc:contributor>
         <dc:date>2006-01-15</dc:date>
-        <chemoinformatics-algorithms:definition
-            >The weighted path (molecular ID) descriptors described by Randic. They characterize molecular branching.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:definition>The weighted path (molecular ID) descriptors described by Randic. They characterize molecular branching.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#wienerNumbers -->
+    <!-- Wiener Numbers -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;wienerNumbers">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#wienerNumbers">
         <rdfs:label>Wiener Numbers</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >Wiener path number and Wiener polarity number.</chemoinformatics-algorithms:definition>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:description
-            >Wiener path number: half the sum of all the distance matrix entries.
+        <chemoinformatics-algorithms:definition>Wiener path number and Wiener polarity number.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>Wiener path number: half the sum of all the distance matrix entries.
             Wiener polarity number: half the sum of all the distance matrix entries with a value of 3.</chemoinformatics-algorithms:description>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#xlogP -->
+    <!-- XLogP -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;xlogP">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#xlogP">
         <rdfs:label>XLogP</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;constitutionalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#constitutionalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2005-01-27</dc:date>
-        <chemoinformatics-algorithms:description
-            >For a description of the methodology see
+        <chemoinformatics-algorithms:definition>Prediction of logP based on the atom-type method called XLogP.</chemoinformatics-algorithms:definition>
+        <chemoinformatics-algorithms:description>For a description of the methodology see
             &lt;bibtex:cite xmlns:bibtex=&quot;http://bibtexml.sf.net/&quot; ref=&quot;WANG97&quot;&gt;&lt;/bibtex:cite&gt;
             .</chemoinformatics-algorithms:description>
-        <chemoinformatics-algorithms:definition
-            >Prediction of logP based on the atom-type method called XLogP.</chemoinformatics-algorithms:definition>
     </owl:Class>
     
 
 
-    <!-- http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#zagrebIndex -->
+    <!-- Zagreb Index -->
 
-    <owl:Class rdf:about="&chemoinformatics-algorithms;zagrebIndex">
+    <owl:Class rdf:about="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#zagrebIndex">
         <rdfs:label>Zagreb Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;MolecularDescriptor"/>
-        <rdfs:subClassOf rdf:resource="&chemoinformatics-algorithms;topologicalDescriptor"/>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;anyURI"
-            >http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
-        <chemoinformatics-algorithms:definition
-            >The sum of the squared atom degrees of all heavy atoms.</chemoinformatics-algorithms:definition>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#MolecularDescriptor"/>
+        <rdfs:subClassOf rdf:resource="http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#topologicalDescriptor"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#elw</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#mf</dc:contributor>
         <dc:date>2004-11-26</dc:date>
+        <chemoinformatics-algorithms:definition>The sum of the squared atom degrees of all heavy atoms.</chemoinformatics-algorithms:definition>
     </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 2.2.1.1138) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
 

--- a/ontology/bodo.owl
+++ b/ontology/bodo.owl
@@ -1,258 +1,480 @@
 <?xml version="1.0"?>
-<!DOCTYPE rdf:RDF [
-    <!ENTITY purl "http://purl.obofoundry.org/" >
-    <!ENTITY bfo "http://www.ifomis.org/bfo/1.1#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY snap "http://www.ifomis.org/bfo/1.1/snap#" >
-    <!ENTITY span "http://www.ifomis.org/bfo/1.1/span#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-    <!ENTITY bodo "http://www.blueobelisk.org/ontologies/chemoinformatics-algorithms/#" >
-]>
-
-
 <rdf:RDF xmlns="http://www.semanticweb.org/ontologies/cheminf-bodo.owl#"
      xml:base="http://www.semanticweb.org/ontologies/cheminf-bodo.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
+     xmlns:cheminf="http://semanticscience.org/ontology/cheminf.owl#"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#"
-     xmlns:resource="http://semanticscience.org/resource/"
-     xmlns:bfo="http://www.ifomis.org/bfo/1.1#"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:cheminf-core="http://semanticscience.org/ontology/cheminf-core.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
-     xmlns:purl="http://purl.obofoundry.org/"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:cheminf1="http://www.semanticweb.org/ontologies/cheminf.owl#"
+     xmlns:bibo="http://purl.org/ontology/bibo/"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
-
-    <owl:Ontology rdf:about="">
-        <dc:contributor rdf:datatype="&xsd;string">Egon Willighagen</dc:contributor>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:title rdf:datatype="&xsd;string"
-            >chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <owl:Ontology rdf:about="http://www.semanticweb.org/ontologies/cheminf-bodo.owl">
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-external.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf.owl"/>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egon Willighagen</dc:contributor>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
     </owl:Ontology>
+    
 
 
-    <!-- Inherited from the Blue Obelisk Descriptor Ontology -->
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000301">
-        <rdfs:label>Algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000064"/>
-    </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000302">
-        <rdfs:label>Implementation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000115"/>
-    </owl:Class>
 
-    <owl:Class rdf:about="&resource;CHEMINF_000303">
-        <rdfs:label>Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000030"/>
-    </owl:Class>
+    <!-- Ertl polar surface area calculation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000304">
-        <rdfs:label>Descriptor Value</rdfs:label>
-    </owl:Class>
-
-    <owl:Class rdf:about="&resource;CHEMINF_000305">
-        <rdfs:label>Molecular Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000309"/>
-    </owl:Class>
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000306">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000306">
         <rdfs:label>Is A</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000301"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000301"/>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
     </owl:ObjectProperty>
+    
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000307">
-        <rdfs:label>Is a modification of</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000306"/>
-        <owl:differentFrom rdf:resource="&resource;CHEMINF_000308"/>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000303"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000303"/>
+
+    <!-- polar surface area descriptor -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000307">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000306"/>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
     </owl:ObjectProperty>
+    
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000308">
-        <rdfs:label>Is a parameterization of</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000306"/>
-        <owl:differentFrom rdf:resource="&resource;CHEMINF_000307"/>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000303"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000303"/>
+
+    <!-- polar surface area descriptor calculated by Pipeline Pilot -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000308">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000306"/>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
     </owl:ObjectProperty>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000309">
-        <rdfs:label>Descriptor Algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000301"/>
+
+    <!-- logP calculated by ACD/Labs PhysChem software -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000321">
+        <rdfs:label>Instance Of</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- logD descriptor -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000322">
+        <rdfs:label>Requires</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000318"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- logD calculated at pH 7.4 by ACD/Labs PhysChem software -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000323">
+        <rdfs:label>Models</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000309"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- most acidic pKa calculated by ACD/Labs PhysChem software library -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000324">
+        <rdfs:label>Describes</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- most basic pKa calculated by ACD/Labs PhysChem software library -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000325">
+        <rdfs:label>Value Point for</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000311"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000303"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- molecular species at pH 7.4 descriptor -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000326">
+        <rdfs:label>Has Part</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000310"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000311"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- molecular species at pH 7.4 calculated by ACD/Labs PhysChem software -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000327">
+        <rdfs:label>Is Calculated by</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000310"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000320"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- should execute with input -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000330">
+        <rdfs:label>Has Parameter</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- should execute with output -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000331">
+        <rdfs:label>Value for</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- PubChem software library -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000332">
+        <rdfs:label>Is Calculated with Parameter</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000310"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- monoisotopic mass calculated by the pubchem software library -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000337">
+        <rdfs:label>Has Descriptor Value</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
+        <rdfs:range rdf:resource="http://semanticscience.org/resource/CHEMINF_000310"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- PubChem software library version 2.1 -->
+
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000333">
+        <rdfs:label>Has Vendor</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- molecular weight calculated by the pubchem software library -->
+
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000334">
+        <rdfs:label>Has Identifier</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- molecular formula calculated by the pubchem software library -->
+
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000335">
+        <rdfs:label>Has Title</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- total formal charge calculated by the pubchem software library -->
+
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000336">
+        <rdfs:label>Has Value</rdfs:label>
+        <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- exact mass calculated by pubchem software library -->
+
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000338">
+        <rdfs:label>Has Version</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- textual definition -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    
+
+
+    <!-- isotope atom count -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000301">
+        <rdfs:label>Algorithm</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000310">
+
+    <!-- PubMed Identifier -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000302">
+        <rdfs:label>Implementation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    </owl:Class>
+    
+
+
+    <!-- GenBank Protein Identifier -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000303">
+        <rdfs:label>Descriptor</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+    </owl:Class>
+    
+
+
+    <!-- GenBank Nucleotide Identifier -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000304">
         <rdfs:label>Descriptor Value</rdfs:label>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000311">
+
+    <!-- ALogP calculated by Pipeline Pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000305">
+        <rdfs:label>Molecular Descriptor</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000309"/>
+    </owl:Class>
+    
+
+
+    <!-- hydrogen bond acceptor count calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000309">
+        <rdfs:label>Descriptor Algorithm</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
+    </owl:Class>
+    
+
+
+    <!-- hydrogen bond donor count calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000310">
+        <rdfs:label>Descriptor Value</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- rotatable bond count calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000311">
         <rdfs:label>Descriptor Value Point</rdfs:label>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000312">
+
+    <!-- rule of five violations descriptor -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000312">
         <rdfs:label>Property</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000030"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000313">
+
+    <!-- Lipinski rule of five violation calculation algorithm -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000313">
         <rdfs:label>Physical Property</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000312"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000314">
+
+    <!-- rule of five violations calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000314">
         <rdfs:label>Computational Property</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000312"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000315">
+
+    <!-- rule of three passes descriptor -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000315">
         <rdfs:label>Atomic Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000309"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000309"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000316">
+
+    <!-- rule of three passes calculation algorithm -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000316">
         <rdfs:label>Bond Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000309"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000309"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000317">
+
+    <!-- rule of three passes calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000317">
         <rdfs:label>Protein Descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000309"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000309"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000318">
+
+    <!-- medchem friendly descriptor -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000318">
         <rdfs:label>Data Feature</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000030"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000319">
+
+    <!-- medchem friendly descriptor calculated by pipeline pilot -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000319">
         <rdfs:label>Data Representation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000318"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000318"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000320">
+
+    <!-- ACD/Labs PhysChem software library -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000320">
         <rdfs:label>Descriptor Implementation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000302"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
     </owl:Class>
+    
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000321">
-        <rdfs:label>Instance Of</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000302"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000301"/>
-    </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000322">
-        <rdfs:label>Requires</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000301"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000318"/>
-    </owl:ObjectProperty>
+    <!-- ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000323">
-        <rdfs:label>Models</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000309"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000312"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000324">
-        <rdfs:label>Describes</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000303"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000312"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000325">
-        <rdfs:label>Value Point for</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000311"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000303"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000326">
-        <rdfs:label>Has Part</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000310"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000311"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000327">
-        <rdfs:label>Is Calculated by</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000310"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000320"/>
-    </owl:ObjectProperty>
-
-    <owl:Class rdf:about="&resource;CHEMINF_000328">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000328">
         <rdfs:label>Parameter</rdfs:label>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="&resource;CHEMINF_000329">
+
+    <!-- Pipeline Pilot Server Version 8.5.0 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000329">
         <rdfs:label>Parameter Value</rdfs:label>
     </owl:Class>
+    
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000330">
-        <rdfs:label>Has Parameter</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000301"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000328"/>
-    </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000331">
-        <rdfs:label>Value for</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000329"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000328"/>
-    </owl:ObjectProperty>
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000332">
-        <rdfs:label>Is Calculated with Parameter</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000310"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000329"/>
-    </owl:ObjectProperty>
+    
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000338">
-        <rdfs:label>Has Version</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000302"/>
-    </owl:DatatypeProperty>
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000333">
-        <rdfs:label>Has Vendor</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000302"/>
-    </owl:DatatypeProperty>
+    <!-- polar surface area descriptor -->
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000334">
-        <rdfs:label>Has Identifier</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000302"/>
-    </owl:DatatypeProperty>
+    <owl:NamedIndividual rdf:about="http://semanticscience.org/resource/CHEMINF_000307"/>
+    
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000335">
-        <rdfs:label>Has Title</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000302"/>
-    </owl:DatatypeProperty>
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000336">
-        <rdfs:label>Has Value</rdfs:label>
-        <rdfs:domain rdf:resource="&owl;Thing"/>
-    </owl:DatatypeProperty>
+    <!-- polar surface area descriptor calculated by Pipeline Pilot -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000337">
-        <rdfs:label>Has Descriptor Value</rdfs:label>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000000"/>
-        <rdfs:range rdf:resource="&resource;CHEMINF_000310"/>
-    </owl:ObjectProperty>
+    <owl:NamedIndividual rdf:about="http://semanticscience.org/resource/CHEMINF_000308"/>
+    
 
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000307">
+        <rdfs:label>Is a modification of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000308">
+        <rdfs:label>Is a parameterization of</rdfs:label>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000307"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000308"/>
+        </owl:distinctMembers>
+    </rdf:Description>
 </rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
+

--- a/ontology/cdk.owl
+++ b/ontology/cdk.owl
@@ -1,81 +1,117 @@
 <?xml version="1.0"?>
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY purl "http://purl.obofoundry.org/" >
-    <!ENTITY bfo "http://www.ifomis.org/bfo/1.1#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY snap "http://www.ifomis.org/bfo/1.1/snap#" >
-    <!ENTITY span "http://www.ifomis.org/bfo/1.1/span#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-    <!ENTITY cdkdesc "http://cdk.sf.net/descriptor/molecular#" >
-]>
-
-
-<rdf:RDF xmlns="http://www.semanticweb.org/ontologies/cdk.owl#"
-     xml:base="http://www.semanticweb.org/ontologies/cdk.owl"
+<rdf:RDF xmlns="http://semanticscience.org/ontology/cdk.owl#"
+     xml:base="http://semanticscience.org/ontology/cdk.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
+     xmlns:cheminf="http://semanticscience.org/ontology/cheminf.owl#"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#"
-     xmlns:resource="http://semanticscience.org/resource/"
-     xmlns:bfo="http://www.ifomis.org/bfo/1.1#"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:cheminf-core="http://semanticscience.org/ontology/cheminf-core.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
-     xmlns:purl="http://purl.obofoundry.org/"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:cheminf1="http://www.semanticweb.org/ontologies/cheminf.owl#"
+     xmlns:bibo="http://purl.org/ontology/bibo/"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
-
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
     <owl:Ontology rdf:about="http://semanticscience.org/ontology/cdk.owl">
-        <dc:contributor rdf:datatype="&xsd;string">Egon Willighagen</dc:contributor>
-        <owl:versionInfo rdf:datatype="&xsd;string">alpha</owl:versionInfo>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:title rdf:datatype="&xsd;string">CDK descriptor algorithm implementations</dc:title>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
-        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
         <rdfs:comment>To develop the ontology, you must change the default auto-create settings in Protege 4. Go to file&gt;preferences&gt;New Entities. Change the following:
 specified URI = http://semanticscience.org/resource/
-Followed by &#39;/&#39;, End with : AutoID
+Followed by &apos;/&apos;, End with : AutoID
 AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
+        <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-algorithms.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-core.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-external.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf.owl"/>
-        <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-algorithms.owl"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alpha</owl:versionInfo>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egon Willighagen</dc:contributor>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
+        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDK descriptor algorithm implementations</dc:title>
     </owl:Ontology>
     
-    <owl:Class rdf:about="&resource;CDK_000001">
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- The Chemistry Development Kit Library -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CDK_000001">
         <rdfs:label>The Chemistry Development Kit Library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
     </owl:Class>
     
-    <owl:Class rdf:about="&resource;CDK_000100">
-        <rdfs:label>org.openscience.cdk.qsar.descriptors.molecular.AtomCountDescriptor</rdfs:label>
+
+
+    <!-- org.openscience.cdk.qsar.descriptors.molecular.AtomCountDescriptor -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CDK_000100">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000451"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000451"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_001000"/>
+                        <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_001000"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <ro:part_of rdf:resource="CDK_000001" />
     </owl:Class>
+    
 
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- org.openscience.cdk.qsar.descriptors.molecular.AtomCountDescriptor -->
+
+    <owl:NamedIndividual rdf:about="http://semanticscience.org/resource/CDK_000100">
+        <obo:BFO_0000050 rdf:resource="http://www.semanticweb.org/ontologies/CDK_000001"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- CDK_000001 -->
+
+    <owl:NamedIndividual rdf:about="http://www.semanticweb.org/ontologies/CDK_000001"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CDK_000100">
+        <rdfs:label>org.openscience.cdk.qsar.descriptors.molecular.AtomCountDescriptor</rdfs:label>
+    </rdf:Description>
 </rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
+

--- a/ontology/cheminf-algorithms.owl
+++ b/ontology/cheminf-algorithms.owl
@@ -1,57 +1,35 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY bfo "http://www.ifomis.org/bfo/1.1#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY snap "http://www.ifomis.org/bfo/1.1/snap#" >
-    <!ENTITY span "http://www.ifomis.org/bfo/1.1/span#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-]>
-
-
-<rdf:RDF xmlns="http://www.semanticweb.org/ontologies/cheminf-algorithms.owl#"
-     xml:base="http://www.semanticweb.org/ontologies/cheminf-algorithms.owl"
+<rdf:RDF xmlns="http://semanticscience.org/ontology/cheminf-algorithms.owl#"
+     xml:base="http://semanticscience.org/ontology/cheminf-algorithms.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
+     xmlns:cheminf="http://semanticscience.org/ontology/cheminf.owl#"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#"
-     xmlns:resource="http://semanticscience.org/resource/"
-     xmlns:bfo="http://www.ifomis.org/bfo/1.1#"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:cheminf-core="http://semanticscience.org/ontology/cheminf-core.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
-     xmlns:purl="http://purl.obofoundry.org/"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:cheminf1="http://www.semanticweb.org/ontologies/cheminf.owl#"
+     xmlns:bibo="http://purl.org/ontology/bibo/"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
     <owl:Ontology rdf:about="http://semanticscience.org/ontology/cheminf-algorithms.owl">
-        <dc:contributor rdf:datatype="&xsd;string">Egon Willighagen</dc:contributor>
-        <owl:versionInfo rdf:datatype="&xsd;string">alpha</owl:versionInfo>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:title rdf:datatype="&xsd;string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
-        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
         <rdfs:comment>To develop the ontology, you must change the default auto-create settings in Protege 4. Go to file&gt;preferences&gt;New Entities. Change the following:
 specified URI = http://semanticscience.org/resource/
 Followed by &apos;/&apos;, End with : AutoID
 AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-core.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-external.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf.owl"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alpha</owl:versionInfo>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egon Willighagen</dc:contributor>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
+        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
     </owl:Ontology>
     
 
@@ -64,36 +42,60 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <rdf:Description rdf:about="&dc;contributor">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000412">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;language">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;format">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;title">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;rights">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <owl:AnnotationProperty rdf:about="&owl;sameAs"/>
     
 
 
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+    <!-- imported from -->
 
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    
+
+
+    <!-- Contributor -->
+
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/contributor">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    
+
+
+    <!-- Format -->
+
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/format">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    
+
+
+    <!-- Language -->
+
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/language">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    
+
+
+    <!-- Rights Management -->
+
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/rights">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    
+
+
+    <!-- Title -->
+
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/title">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    
+
+
+    <!-- sameAs -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#sameAs"/>
     
 
 
@@ -108,17 +110,17 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001000 -->
+    <!-- atom counting algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001000">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001000">
         <rdfs:label>atom counting algorithm</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000450"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000450"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000263"/>
+                        <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -136,10 +138,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000101">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;integral_part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -148,40 +147,10 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000100">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000054">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000105">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000011">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000104">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000314">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000315">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000312">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000313">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000310">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000311">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000309">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;transformation_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -190,300 +159,431 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000308">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/GAZ"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;GAZ_00000448">
-        <obo:IAO_0000412 rdf:resource="&obo;GAZ"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000001">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;iao.owl">
-        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000003">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000307">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000005">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000306">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000006">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000305">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000007">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000180">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000182">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000009">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000181">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000184">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000183">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000013">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000047">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000015">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000186">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000017">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000185">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000111">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000583">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000584">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000025">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000112">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000115">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000589">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000032">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;proper_part_of">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000117">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000034">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000116">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000035">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000301">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000037">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000302">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000038">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;improper_part_of">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000303">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000055">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;iao/obsolete.owl">
-        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000057">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000304">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000059">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000442">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000064">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000581">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000065">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000443">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000078">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000582">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000079">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000580">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000109">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000091">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000059">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000057">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000096">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000055">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000097">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000576">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000098">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000579">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000100">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000572">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000101">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;has_agent">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000104">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000573">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000574">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000109">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000575">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;publisher">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000065">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000064">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000283">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000230"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000471">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;creator">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000179">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000128">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000121"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000178">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000129">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;has_participant">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000131">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000079">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000132">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;date">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000135">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;located_in">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000136">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000078">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000140">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000006">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000007">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000142">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000005">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000144">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000141">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000178">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000003">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000179">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;relationship">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000180">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000142">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000181">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000140">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000182">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000001">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000183">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;PATO_0000125">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000184">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000185">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000186">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000225">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000301">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000302">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000303">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000304">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000305">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000306">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000307">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000308">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000309">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000311">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000312">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000313">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000314">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000315">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000316">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000317">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000318">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000319">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000320">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000321">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000322">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000323">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000324">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000325">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000326">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000327">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000328">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000329">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000330">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000400">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000401">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000402">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000403">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000408">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000413">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000414">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000415">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000416">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000417">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000418">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000419">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000442">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000443">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000572">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000573">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000574">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000575">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000576">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000579">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000580">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000581">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000582">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000583">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000584">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000011">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000066">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000283">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000230"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000471">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000122">
         <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000144">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;preceded_by">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;source">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000088">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000401">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000400">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000403">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;PATO_0000122">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000125">
         <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000402">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000015">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000017">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0500000">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000018">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000226"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;description">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000012">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -492,106 +592,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000013">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;identifier">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000010">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000066">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000408">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000001">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000003">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000002">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000414">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;subject">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000413">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000097">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000098">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000096">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000009">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000093">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000008">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000091">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000024">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000025">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;contained_in">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000027">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000419">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000128">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000121"/>
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000226"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000318">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000415">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000416">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000319">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000417">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000316">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;derives_from">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001000">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -603,123 +604,7 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
             <rdf:Description/>
         </oboInOwl:hasExactSynonym>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000317">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000418">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000326">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000325">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000324">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000323">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000322">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000321">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000119">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000320">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000118">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;type">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000223">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000222">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000220">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000019">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000225">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000033">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000034">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000035">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000131">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000037">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000038">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000300">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000136">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000132">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000327">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000328">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000030">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000329">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000032">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000135">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0100001">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;coverage">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000129">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000330">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000232">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;iao/iao-main.owl">
-        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;adjacent_to">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001018">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -728,12 +613,129 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;relation">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001025">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002218">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002220">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002494">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000001">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000002">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000003">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/iao.owl">
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/iao/iao-main.owl">
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/iao/obsolete.owl">
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/coverage">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/creator">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/date">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/description">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/identifier">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/publisher">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/relation">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/subject">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/type">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#improper_part_of">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#integral_part_of">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#proper_part_of">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#relationship">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
     </rdf:Description>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.2.5.1928) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
 

--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -4324,6 +4324,13 @@ The formal charge of any atom in a molecule can be calculated by the following e
     </owl:Class>
     
 
+    <!-- http://semanticscience.org/resource/CHEMINF_000567 -->
+
+    <owl:Class rdf:about="&resource;CHEMINF_000567">
+        <rdfs:label>Wikidata identifier</rdfs:label>
+        <dc:description>Database identifier used by Wikidata.</dc:description>
+    </owl:Class>
+
 
     <!-- http://semanticscience.org/resource/CHEMINF_000411 -->
 

--- a/ontology/cheminf-core.owl
+++ b/ontology/cheminf-core.owl
@@ -1,53 +1,33 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-]>
-
-
 <rdf:RDF xmlns="http://semanticscience.org/ontology/cheminf-core.owl#"
      xml:base="http://semanticscience.org/ontology/cheminf-core.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
-     xmlns:resource="http://semanticscience.org/resource/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:cheminf-core="http://semanticscience.org/ontology/cheminf-core.owl#">
     <owl:Ontology rdf:about="http://semanticscience.org/ontology/cheminf-core.owl">
-        <owl:versionInfo rdf:datatype="&xsd;string">1.0.1</owl:versionInfo>
-        <dc:contributor rdf:datatype="&xsd;string">Colin Batchelor</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Egon Willighagen</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Janna Hastings</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Michel Dumontier</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Ola Spjuth</dc:contributor>
-        <rdfs:comment rdf:datatype="&xsd;string">The chemical information ontology (cheminf) intends to describe information entities about chemical entities. It means to provide  qualitative and quantitative attributes to richly describe chemicals.</rdfs:comment>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:title rdf:datatype="&xsd;string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
-        <dc:contributor>Leonid Chepelev</dc:contributor>
-        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The chemical information ontology (cheminf) intends to describe information entities about chemical entities. It means to provide  qualitative and quantitative attributes to richly describe chemicals.</rdfs:comment>
         <rdfs:comment>To develop the ontology, you must change the default auto-create settings in Protege 4. Go to file&gt;preferences&gt;New Entities. Change the following:
 specified URI = http://semanticscience.org/resource/
 Followed by &apos;/&apos;, End with : AutoID
 AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.0.1</owl:versionInfo>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Colin Batchelor</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egon Willighagen</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Janna Hastings</dc:contributor>
+        <dc:contributor>Leonid Chepelev</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Michel Dumontier</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ola Spjuth</dc:contributor>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
+        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
     </owl:Ontology>
     
 
@@ -63,87 +43,87 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+    <!-- IAO_0000115 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
+    <!-- IAO_0000117 -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000117"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/contributor -->
+    <!-- contributor -->
 
-    <owl:AnnotationProperty rdf:about="&dc;contributor"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/description -->
+    <!-- description -->
 
-    <owl:AnnotationProperty rdf:about="&dc;description"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/format -->
+    <!-- format -->
 
-    <owl:AnnotationProperty rdf:about="&dc;format"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/format"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/language -->
+    <!-- language -->
 
-    <owl:AnnotationProperty rdf:about="&dc;language"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/language"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/rights -->
+    <!-- rights -->
 
-    <owl:AnnotationProperty rdf:about="&dc;rights"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/rights"/>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/title -->
+    <!-- title -->
 
-    <owl:AnnotationProperty rdf:about="&dc;title"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
     
 
 
-    <!-- http://semanticscience.org/ontology/cheminf-core.owl#short_name -->
+    <!-- short_name -->
 
     <owl:AnnotationProperty rdf:about="http://semanticscience.org/ontology/cheminf-core.owl#short_name"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
+    <!-- hasAlternativeId -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasAlternativeId"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+    <!-- comment -->
 
-    <owl:AnnotationProperty rdf:about="&rdfs;comment"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
+    <!-- label -->
 
-    <owl:AnnotationProperty rdf:about="&rdfs;label"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#versionInfo -->
+    <!-- versionInfo -->
 
-    <owl:AnnotationProperty rdf:about="&owl;versionInfo"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#versionInfo"/>
     
 
 
-    <!-- http://www.w3.org/2004/02/skos/core#prefLabel -->
+    <!-- prefLabel -->
 
-    <owl:AnnotationProperty rdf:about="&skos;prefLabel"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel"/>
     
 
 
@@ -158,112 +138,112 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
+    <!-- BFO_0000051 -->
 
-    <owl:ObjectProperty rdf:about="&obo;IAO_0000136">
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
+    
+
+
+    <!-- is about -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000136">
         <rdfs:label>is about</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0000299 -->
+    <!-- OBI_0000299 -->
 
-    <owl:ObjectProperty rdf:about="&obo;OBI_0000299"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000299"/>
     
 
 
-    <!-- http://purl.org/obo/owl/OBO_REL#bearer_of -->
+    <!-- RO_0000053 -->
 
-    <owl:ObjectProperty rdf:about="&OBO_REL;bearer_of"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000047 -->
+    <!-- RO_0000057 -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000047">
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057"/>
+    
+
+
+    <!-- conforms to -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000047">
         <rdfs:label>conforms to</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000143 -->
+    <!-- is descriptor of -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000143">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000143">
         <rdfs:label>is descriptor of</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000145 -->
+    <!-- has output -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000145">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000145">
         <rdfs:label>has output</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000148 -->
+    <!-- has input -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000148">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000148">
         <rdfs:label>has input</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000204 -->
+    <!-- is variant of -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000204">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000204">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
         <rdfs:label>is variant of</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000330 -->
+    <!-- should execute with input -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000330">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000330">
         <rdfs:label>should execute with input</rdfs:label>
-        <rdfs:range rdf:resource="&obo;IAO_0000027"/>
-        <rdfs:domain rdf:resource="&obo;IAO_0000064"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000331 -->
+    <!-- should execute with output -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000331">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000331">
         <rdfs:label>should execute with output</rdfs:label>
-        <rdfs:range rdf:resource="&obo;IAO_0000027"/>
-        <rdfs:domain rdf:resource="&obo;IAO_0000064"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000606 -->
+    <!-- is execution output of -->
 
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000606">
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000606">
         <rdfs:label>is execution output of</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_part -->
+    <!-- has_proper_part -->
 
-    <owl:ObjectProperty rdf:about="&ro;has_part"/>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_participant -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_participant"/>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_proper_part -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_proper_part">
-        <rdfs:subPropertyOf rdf:resource="&ro;has_part"/>
+    <owl:ObjectProperty rdf:about="http://www.obofoundry.org/ro/ro.owl#has_proper_part">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
     </owl:ObjectProperty>
     
 
@@ -279,58 +259,58 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
+    <!-- IAO_0000004 -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000004">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000404 -->
+    <!-- IAO_0000404 -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000404">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000404">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000405 -->
+    <!-- IAO_0000405 -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000405">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000405">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000406 -->
+    <!-- IAO_0000406 -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000406">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000406">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000009 -->
+    <!-- has uncertainty value -->
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000009">
-        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000009">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:label>has uncertainty value</rdfs:label>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000012 -->
+    <!-- has value -->
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000012">
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000012">
         <rdfs:label>has value</rdfs:label>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://www.w3.org/2004/02/skos/core#prefLabel -->
+    <!-- prefLabel -->
 
-    <owl:DatatypeProperty rdf:about="&skos;prefLabel"/>
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/2004/02/skos/core#prefLabel"/>
     
 
 
@@ -345,106 +325,106 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_23367 -->
+    <!-- molecular entity -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23367">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23367">
         <rdfs:label>molecular entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000000"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
         <oboInOwl:hasAlternativeId>CHEBI:23367</oboInOwl:hasAlternativeId>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_33250 -->
+    <!-- atom -->
 
-    <owl:Class rdf:about="&obo;CHEBI_33250">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33250">
         <rdfs:label>atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000000"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
         <oboInOwl:hasAlternativeId>CHEBI:33250</oboInOwl:hasAlternativeId>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_36357 -->
+    <!-- polyatomic entity -->
 
-    <owl:Class rdf:about="&obo;CHEBI_36357">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36357">
         <rdfs:label>polyatomic entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <oboInOwl:hasAlternativeId>CHEBI:36357</oboInOwl:hasAlternativeId>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
+    <!-- IAO_0000027 -->
 
-    <owl:Class rdf:about="&obo;IAO_0000027">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&rdfs;Literal"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000064 -->
+    <!-- IAO_0000064 -->
 
-    <owl:Class rdf:about="&obo;IAO_0000064"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000064"/>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000109 -->
+    <!-- IAO_0000109 -->
 
-    <owl:Class rdf:about="&obo;IAO_0000109">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000009"/>
-                <owl:someValuesFrom rdf:resource="&xsd;float"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000009"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000403 -->
+    <!-- IAO_0000403 -->
 
-    <owl:Class rdf:about="&obo;IAO_0000403"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000403"/>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/PATO_0000122 -->
+    <!-- length -->
 
-    <owl:Class rdf:about="&obo;PATO_0000122">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000122">
         <rdfs:label>length</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;PATO_0001708"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001708"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/PATO_0000125 -->
+    <!-- mass -->
 
-    <owl:Class rdf:about="&obo;PATO_0000125">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000125">
         <rdfs:label>mass</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
         <rdfs:comment>from PATO</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/PATO_0001708 -->
+    <!-- 1-D extent -->
 
-    <owl:Class rdf:about="&obo;PATO_0001708">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001708">
         <rdfs:label>1-D extent</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000211"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000211"/>
         <dc:description>A one dimensional extent is a dimensional extent in only one dimension, e.g. a length.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000000 -->
+    <!-- chemical entity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000000">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000000">
         <rdfs:label>chemical entity</rdfs:label>
         <dc:description>A chemical entity is any molecular entity or chemical substance.</dc:description>
         <oboInOwl:hasAlternativeId>CHEBI:24431</oboInOwl:hasAlternativeId>
@@ -452,115 +432,115 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000001 -->
+    <!-- molar refractivity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000001">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000001">
         <rdfs:label>molar refractivity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
         <dc:description>Molar refractviity is a measure of the total polarizability of a mole of a substance and is dependent on the temperature, the index of refraction, and the pressure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000002 -->
+    <!-- atomic polarizability sum -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000002">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000002">
         <rdfs:label>atomic polarizability sum</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
         <dc:description>atomic polarizability sum is the sum of the atomic polarizabilities (including implicit hydrogens).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000003 -->
+    <!-- partial positive surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000003">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000003">
         <rdfs:label>partial positive surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>PPSA-1</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>sum of surface area on positive parts of molecule</dc:description>
+        <short_name>PPSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000004 -->
+    <!-- PPSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000004">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000004">
         <rdfs:label>PPSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>partial positive surface area * total positive charge on the molecule</dc:description>
         <short_name>PPSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000005 -->
+    <!-- RS stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000005">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000005">
         <rdfs:label>RS stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000074"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000024"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000024"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000074"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000006 -->
+    <!-- R stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000006">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000006">
         <rdfs:label>R stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000005"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000034"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000005"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000034"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000007 -->
+    <!-- canonical SMILES descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000007">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000007">
         <rdfs:label>canonical SMILES descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000018"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000018"/>
         <dc:description>A canonical SMILES descriptor is a SMILES descriptor that is produced using a canonicalization algorithm which results in one special generic SMILES among all valid possibilities.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000008 -->
+    <!-- charge weighted partial positive surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000008">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000008">
         <rdfs:label>charge weighted partial positive surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>PPSA-3</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>charge weighted partial positive surface area</dc:description>
+        <short_name>PPSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000010 -->
+    <!-- atomic order -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000010">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000010">
         <rdfs:label>atomic order</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000041"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000041"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Atomic order is an atomic descriptor that specifies the ordinal position of an atom.</dc:description>
@@ -568,86 +548,86 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000011 -->
+    <!-- partial negative surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000011">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000011">
         <rdfs:label>partial negative surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>sum of surface area on negative parts of molecule</dc:description>
         <short_name>PNSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000013 -->
+    <!-- chirality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000013">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000013">
         <rdfs:label>chirality</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Chirality is a molecular entity quality which inheres in a molecular entity by virtue of the existence of another molecular entity which is the  mirror image of the first one, yet non-superposable on it.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000014 -->
+    <!-- chemical entity information format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000014">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000014">
         <rdfs:label>chemical entity information format specification</rdfs:label>
         <dc:description>A chemical entity information format specification is an information content entity which specifies a format in which information about a molecular entity should be encoded.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000015 -->
+    <!-- PNSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000015">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000015">
         <rdfs:label>PNSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>partial negative surface area * total negative charge on the molecule</dc:description>
         <short_name>PNSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000016 -->
+    <!-- energetic descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000016">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000016">
         <rdfs:label>energetic descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>An energetic descriptor is a chemical descriptor which captures information about some aspect of the energetic behaviour of a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000017 -->
+    <!-- information about a chemical entity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000017">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000017">
         <rdfs:label>information about a chemical entity</rdfs:label>
         <owl:equivalentClass>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000000"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
             </owl:Restriction>
         </owl:equivalentClass>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000018 -->
+    <!-- SMILES descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000018">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000018">
         <rdfs:label>SMILES descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000020"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000020"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A SMILES descriptor is a structure descriptor that denotes a molecular structure as a graph.</dc:description>
@@ -655,21 +635,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000019 -->
+    <!-- SMARTS descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000019">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000019">
         <rdfs:label>SMARTS descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000021"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000021"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A SMARTS descriptor is a molecular structure descriptor that conforms to the SMARTS specification.</dc:description>
@@ -677,83 +657,83 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000020 -->
+    <!-- SMILES format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000020">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000020">
         <rdfs:label>SMILES format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000035"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000035"/>
         <dc:description>The simplified molecular input line entry specification (SMILES) is a specification for unambiguously describing the structure of chemical molecules using short ASCII strings. SMILES strings can be imported by most molecule editors for conversion back into two-dimensional drawings or three-dimensional models of the molecules (source:wikipedia).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000021 -->
+    <!-- SMARTS format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000021">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000021">
         <rdfs:label>SMARTS format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000035"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000035"/>
         <dc:description>Smiles ARbitrary Target Specification (SMARTS) is a language for specifying substructural patterns in molecules. The SMARTS line notation is expressive and allows extremely precise and transparent substructural specification and atom typing (source:Wikipedia)</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000022 -->
+    <!-- molecular structure encoding format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000022">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000022">
         <rdfs:label>molecular structure encoding format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000014"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000014"/>
         <dc:description>A molecular structure encoding format specification is a molecular entity format specification which specifies a format in which a molecular structure information entity may be encoded.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000023 -->
+    <!-- molecular stereochemistry format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000023">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000023">
         <rdfs:label>molecular stereochemistry format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000022"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000022"/>
         <dc:description>A molecular stereochemistry format specification is a molecular structure format specification that specifies how to encode the stereochemical aspects of a molecular structure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000024 -->
+    <!-- RS stereochemistry specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000024">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000024">
         <rdfs:label>RS stereochemistry specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000028"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000028"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000025 -->
+    <!-- physical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000025">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000025">
         <rdfs:label>physical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A physical descriptor is a chemical descriptor which describes some physical property (quality or disposition) of a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000026 -->
+    <!-- DL stereochemistry specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000026">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000026">
         <rdfs:label>DL stereochemistry specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000028"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000028"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000027 -->
+    <!-- stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000027">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000027">
         <rdfs:label>stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000013"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000013"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A stereochemical descriptor is a chemical descriptor which describes some aspect of the three dimensional structure of a chemical entity.</dc:description>
@@ -761,48 +741,48 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000028 -->
+    <!-- specification of stereochemistry by configuration -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000028">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000028">
         <rdfs:label>specification of stereochemistry by configuration</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000023"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000023"/>
         <dc:description>A specification of stereochemistry by configuration specifies a format in which the stereochemistry of a molecule should be encoded with reference to the configuration of attachments around the stereogenic centre.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000029 -->
+    <!-- specification of stereochemistry by optical activity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000029">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000029">
         <rdfs:label>specification of stereochemistry by optical activity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000023"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000023"/>
         <dc:description>A specification of stereochemistry by optical activity specifies a format by which the stereochemistry of a molecule should be encoded by reference to the observable optical activity of a chiral molecule.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000030 -->
+    <!-- +/- stereochemistry specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000030">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000030">
         <rdfs:label>+/- stereochemistry specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000029"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000029"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000031 -->
+    <!-- molecular entity quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000031">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000031">
         <rdfs:label>molecular entity quality</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000086"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000086"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty>
                     <rdf:Description>
-                        <owl:inverseOf rdf:resource="&OBO_REL;bearer_of"/>
+                        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
                     </rdf:Description>
                 </owl:onProperty>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A molecular entity quality is a quality which inheres in a molecular entity.</dc:description>
@@ -810,119 +790,119 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000032 -->
+    <!-- isomeric SMILES descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000032">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000032">
         <rdfs:label>isomeric SMILES descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000018"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000018"/>
         <dc:description>an isomeric SMILES descriptor is a SMILES descriptor that written with isotopic and chiral specifications.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000033 -->
+    <!-- molecular structure -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000033">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000033">
         <rdfs:label>molecular structure</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Molecular structure is a molecular entity quality that inheres in a molecule by virtue of its shape - the way in which the atoms which constitute the molecule are bonded together and the shape which they therefore form.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000034 -->
+    <!-- S stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000034">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000034">
         <rdfs:label>S stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000005"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000005"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000035 -->
+    <!-- atomic connectivity molecular structure encoding format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000035">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000035">
         <rdfs:label>atomic connectivity molecular structure encoding format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000022"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000022"/>
         <dc:description>An atomic connectivity molecular structure encoding format specification is a molecular structure encoding format specification which specifies a format in which the connectivity of atoms within a molecule may be specified.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000036 -->
+    <!-- molecular composition format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000036">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000036">
         <rdfs:label>molecular composition format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000014"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000014"/>
         <dc:description>A molecular composition format specification is a molecular entity information format specification which specifies a format in which a molecular composition may be encoded.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000037 -->
+    <!-- IUPAC chemical formula -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000037">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000037">
         <rdfs:label>IUPAC chemical formula</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000036"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000036"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000038 -->
+    <!-- InChI format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000038">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000038">
         <rdfs:label>InChI format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000035"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000035"/>
         <dc:description>The IUPAC International Chemical Identifier (InChI) is a textual identifier  for chemical substances, designed to provide a standard and human-readable way to encode molecular information and to facilitate the search for such information in databases and on the web. Developed by IUPAC and NIST during 2000-2005, the format and algorithms are non-proprietary and the software is freely available under the open source LGPL license (though the term &quot;InChI&quot; is a trademark  of IUPAC). [source: Wikipedia, http://en.wikipedia.org/wiki/International_Chemical_Identifier]</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000039 -->
+    <!-- molecular entity name format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000039">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000039">
         <rdfs:label>molecular entity name format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000014"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000014"/>
         <dc:description>A molecular entity name format specification is a molecular entity information format specification which specifies a format in which a molecular entity name may be encoded.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000040 -->
+    <!-- Preferred IUPAC Name for Organic Compounds -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000040">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000040">
         <rdfs:label>Preferred IUPAC Name for Organic Compounds</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000039"/>
         <rdfs:comment>http://www.iupac.org/web/ins/2001-043-1-800</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000039"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000041 -->
+    <!-- positional descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000041">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000041">
         <rdfs:label>positional descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A positional descriptor is a chemical descriptor which describes some aspect of the position, or location of a chemical entity, or of the relative parts of a chemical entity with respct to one another.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000042 -->
+    <!-- molecular formula -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000042">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000042">
         <rdfs:label>molecular formula</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000054"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000054"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A molecular formula is a structure descriptor which identifies each constituent element by its chemical symbol and indicates the number of atoms of each element found in each discrete molecule of that compound.</dc:description>
@@ -930,21 +910,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000043 -->
+    <!-- molecular entity name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000043">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000043">
         <rdfs:label>molecular entity name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000061"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000061"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000039"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000039"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An information entity about a molecular entity which serves to name that molecular entity.</dc:description>
@@ -952,141 +932,141 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000044 -->
+    <!-- preferred name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000044">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000044">
         <rdfs:label>preferred name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <dc:description>A preferred name is a molecular entity name which is preferred, or recommended, for usage in textual annotations referring to that molecular entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000045 -->
+    <!-- Preferred IUPAC Name for Inorganic Compounds -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000045">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000045">
         <rdfs:label>Preferred IUPAC Name for Inorganic Compounds</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000039"/>
         <rdfs:comment>http://www.iupac.org/web/ins/2006-038-1-800</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000039"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000046 -->
+    <!-- zagreb index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000046">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000046">
         <rdfs:label>zagreb index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <dc:description>The sum of the squared atom degrees of all heavy atoms.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000048 -->
+    <!-- +/- stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000048">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000048">
         <rdfs:label>+/- stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000074"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000030"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000030"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000074"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000049 -->
+    <!-- + stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000049">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000049">
         <rdfs:label>+ stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000048"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000050"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000048"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000050"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000050 -->
+    <!-- - stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000050">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000050">
         <rdfs:label>- stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000048"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000048"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000051 -->
+    <!-- DL stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000051">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000051">
         <rdfs:label>DL stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000074"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000074"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000052 -->
+    <!-- D stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000052">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000052">
         <rdfs:label>D stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000051"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000053"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000051"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000053"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000053 -->
+    <!-- L stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000053">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000053">
         <rdfs:label>L stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000051"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000051"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000054 -->
+    <!-- molecular composition -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000054">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000054">
         <rdfs:label>molecular composition</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Molecular composition is a molecular entity quality that inheres in a molecule by virtue of the atoms which constitute the molecule.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000055 -->
+    <!-- chemical connectivity table -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000055">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000055">
         <rdfs:label>chemical connectivity table</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A chemical connectivity table is a structure descriptor which consists of a connection table representing bonds between atoms in a molecular entity.</dc:description>
@@ -1094,21 +1074,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000056 -->
+    <!-- aromaticity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000056">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000056">
         <rdfs:label>aromaticity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000115"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000115"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An aromaticity descriptor is a chemical descriptor which indicates the aromaticity of a molecular entity.</dc:description>
@@ -1116,60 +1096,60 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000058 -->
+    <!-- MOLfile -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000058">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000058">
         <rdfs:label>MOLfile</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000017"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000017"/>
         <dc:description>A MOLfile is a file which contains a MOLfile encoding of a chemical structure representation. It is the concretization of a MOLfile descriptor.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000059 -->
+    <!-- InChIKey -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000059">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000059">
         <rdfs:label>InChIKey</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000061"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000061"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_36357"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000060 -->
+    <!-- dimensional extent descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000060">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000060">
         <rdfs:label>dimensional extent descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <dc:description>A dimensional extent descriptor is a physical property descriptor which describes some measurable length, area or volume aspect of a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000061 -->
+    <!-- identifying descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000061">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000061">
         <rdfs:label>identifying descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>An identifying descriptor is a chemical descriptor which provides an identifier for the chemical entity it is about, which in most cases should aim to be unique and easy to use as an unambiguous reference for the chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000062 -->
+    <!-- bond order descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000062">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000062">
         <rdfs:label>bond order descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A bond order descriptor is a descriptor associated with a bond in a chemical entity which indicates the order of the bond (single, double or triple).</dc:description>
@@ -1177,50 +1157,50 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000063 -->
+    <!-- chemical bond -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000063">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000063">
         <rdfs:label>chemical bond</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000000"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000064 -->
+    <!-- QSAR descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000064">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000064">
         <rdfs:label>QSAR descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A Quantitative Structure Activity Relationship (QSAR) descriptor is a chemical descriptor which gives a numeric, quantitative value which is believed to be associated with some aspect of the chemical or biological activity of the chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000065 -->
+    <!-- molecular entity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000065">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000065">
         <rdfs:label>molecular entity descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000123"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                        <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000014"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000014"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>a molecular entity descriptor is a chemical descriptor that provides information about a molecular entity.</dc:description>
@@ -1228,46 +1208,46 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000066 -->
+    <!-- information about a polyatomic entity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000066">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000066">
         <rdfs:label>information about a polyatomic entity</rdfs:label>
+        <rdfs:comment>An information entity which is about a polyatomic molecular entity.</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000017"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000017"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                        <owl:someValuesFrom rdf:resource="&obo;CHEBI_36357"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000017"/>
-        <rdfs:comment>An information entity which is about a polyatomic molecular entity.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000017"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000067 -->
+    <!-- cyclicity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000067">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000067">
         <rdfs:label>cyclicity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>cyclicity is a quality that inheres in a molecular entity by virtue of the presence of cycles in the connection of the atoms within the molecular entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000068 -->
+    <!-- functional group descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000068">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000068">
         <rdfs:label>functional group descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A functional group descriptor is a structural descriptor which describes specific groups of atoms within molecules that are responsible for the characteristic chemical reactions of those molecules.</dc:description>
@@ -1275,113 +1255,113 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000069 -->
+    <!-- polarity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000069">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000069">
         <rdfs:label>polarity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Polarity is a quality that inheres in a molecular entity by virtue of whether or not the molecular entity has a separation of electric charge which leads to the molecule having an electric dipole.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000070 -->
+    <!-- polar -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000070">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000070">
         <rdfs:label>polar</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000069"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000071"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000069"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000071"/>
         <dc:description>Polar polarity is a quality that inheres in a molecular entity when the molecular entity is polar, i.e. does possess an electric dipole.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000071 -->
+    <!-- nonpolar -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000071">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000071">
         <rdfs:label>nonpolar</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000069"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000069"/>
         <dc:description>Nonpolar polarity is a quality which inheres in a molecular entity when the molecular entity does not possess an electrical dipole.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000072 -->
+    <!-- cyclic -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000072">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000072">
         <rdfs:label>cyclic</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000067"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000073"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000067"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000073"/>
         <dc:description>Cyclic cyclicity inheres in a molecule when the atoms of the molecule do contain at least one cycle in the atom-atom connection paths (through bonds).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000073 -->
+    <!-- acyclic -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000073">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000073">
         <rdfs:label>acyclic</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000067"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000067"/>
         <dc:description>Acyclic cyclicity inheres in a molecule when the atoms within the molecule do not contain at least one cycle in the atom-atom connection paths (through the bonds).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000074 -->
+    <!-- chiral -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000074">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000074">
         <rdfs:label>chiral</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000013"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000075"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000013"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000075"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000075 -->
+    <!-- achiral -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000075">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000075">
         <rdfs:label>achiral</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000013"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000013"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000076 -->
+    <!-- aromatic -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000076">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000076">
         <rdfs:label>aromatic</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000115"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000077"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000115"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000077"/>
         <dc:description>Aromatic aromaticity is a quality that inheres in a molecular entity when it possesses at least one ring that is aromatic.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000077 -->
+    <!-- non-aromatic -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000077">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000077">
         <rdfs:label>non-aromatic</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000115"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000115"/>
         <dc:description>Non aromatic aromaticity is a quality that inheres in a molecular entity by virtue of the molecule possessing no rings that are aromatic.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000078 -->
+    <!-- neutron count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000078">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000078">
         <rdfs:label>neutron count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000054"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000054"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The (integer) number of neutrons in the atoms nucleus.</dc:description>
@@ -1389,21 +1369,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000079 -->
+    <!-- proton count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000079">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000079">
         <rdfs:label>proton count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000054"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000054"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The (integer) number of protons in the atoms nucleus.</dc:description>
@@ -1411,119 +1391,119 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000080 -->
+    <!-- cis-trans stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000080">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000080">
         <rdfs:label>cis-trans stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000027"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000220"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment>Descriptors which show the relationship between two ligands attached to separate atoms that are connected by a double bond or are contained in a ring. The two ligands are said to be located cis to each other if they lie on the same side of a plane. If they are on opposite sides, their relative position is described as trans. The appropriate reference plane of a double bond is perpendicular to that of the relevant s-bonds and passes through the double bond.[source:IUPAC Gold Book - http://goldbook.iupac.org/C01092.html]</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000027"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000220"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000081 -->
+    <!-- cis stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000081">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000081">
         <rdfs:label>cis stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000080"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000080"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000082 -->
+    <!-- trans stereochemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000082">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000082">
         <rdfs:label>trans stereochemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000080"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000080"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000083 -->
+    <!-- mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000083">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000083">
         <rdfs:label>mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&obo;PATO_0000125"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000125"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000084 -->
+    <!-- atomic mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000084">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000084">
         <rdfs:label>atomic mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000083"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000083"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000085 -->
+    <!-- structural descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000085">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000085">
         <rdfs:label>structural descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A structural descriptor is a chemical descriptor which is about some aspect of the molecular structure (composition) of a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000086 -->
+    <!-- chemical quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000086">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000086">
         <rdfs:label>chemical quality</rdfs:label>
         <dc:description>A chemical quality is a quality that inheres in a molecular entity or aggregate molecular substance.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000087 -->
+    <!-- electronic descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000087">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000087">
         <rdfs:label>electronic descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000088 -->
+    <!-- molecular mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000088">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000088">
         <rdfs:label>molecular mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000083"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000083"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_36357"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36357"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>The mass of a molecule calculated according to some assumption about the isotopic identity of the atoms constituting it.</obo:IAO_0000115>
@@ -1532,24 +1512,24 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000089 -->
+    <!-- polarizability -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000089">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000089">
         <rdfs:label>polarizability</rdfs:label>
         <dc:description>The ease of distortion of the electron cloud of a molecular entity by an electric field [source: IUPAC Gold Book - http://goldbook.iupac.org/P04711.html]</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000090 -->
+    <!-- atomic degree -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000090">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000090">
         <rdfs:label>atomic degree</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The integer number of non-H substituents of an atom.</dc:description>
@@ -1557,60 +1537,60 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000091 -->
+    <!-- hybridization -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000091">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000091">
         <rdfs:label>hybridization</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>The quality of an atom that reflects the combination of its atomic orbitals to create bonding orbitals.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000092 -->
+    <!-- topological descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000092">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000092">
         <rdfs:label>topological descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A topological descriptor is a chemical descriptor which pertains to spatial properties of a geometric object that are preserved under continuous deformations of objects, for example, deformations that involve stretching.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000093 -->
+    <!-- geometric descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000093">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000093">
         <rdfs:label>geometric descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
         <dc:description>A geometric descriptor is a descriptor that concerns information about size, shape, and relative position.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000094 -->
+    <!-- charge delocalization descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000094">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000094">
         <rdfs:label>charge delocalization descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000095 -->
+    <!-- hybridization descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000095">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000095">
         <rdfs:label>hybridization descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000091"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000091"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A hybridization descriptor is a chemical descriptor that is about the hybridization of atomic orbitals in a molecular entity.</dc:description>
@@ -1618,15 +1598,15 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000096 -->
+    <!-- atomic valence -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000096">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000096">
         <rdfs:label>atomic valence</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Atomic valence is an atomic descriptor that specifies the maximum number of univalent atoms (originally hydrogen or chlorine atoms) which may combine with an atom of the element under consideration, or with a fragment, or for which an atom of this element can be substituted [source: IUPAC Gold Book - http://goldbook.iupac.org/V06588.html]</dc:description>
@@ -1634,15 +1614,15 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000097 -->
+    <!-- atomic hardness descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000097">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000097">
         <rdfs:label>atomic hardness descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An atomic hardness descriptor is an atomic descriptor that estimates the difference between the ionization potential and the electron affinity of a given atom.</dc:description>
@@ -1650,25 +1630,25 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000098 -->
+    <!-- valency -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000098">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000098">
         <rdfs:label>valency</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Valency is an atomic quality of the number of chemical bonds formed by the atom.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000099 -->
+    <!-- atomic softness descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000099">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000099">
         <rdfs:label>atomic softness descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An atomic softness descriptor is an atomic descriptor which is about the charge delocalizing ability of a given atom.</dc:description>
@@ -1676,29 +1656,29 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000100 -->
+    <!-- MOLfile format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000100">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000100">
         <rdfs:label>MOLfile format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000035"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000035"/>
         <dc:description>The MOLfile atomic connectivity molecular structure encoding format specification may be found described at http://en.wikipedia.org/wiki/Chemical_table_file#Molfiles. It is composed primarily of a connection table (atoms and bonds); hydrogen may be implicit or explicit.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000101 -->
+    <!-- chemical substance quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000101">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000101">
         <rdfs:label>chemical substance quality</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000086"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000086"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty>
                     <rdf:Description>
-                        <owl:inverseOf rdf:resource="&OBO_REL;bearer_of"/>
+                        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
                     </rdf:Description>
                 </owl:onProperty>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A chemical substance quality is a quality that inheres in an aggregate molecular substance, such as a portion of solid or liquid matter.</dc:description>
@@ -1706,30 +1686,30 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000102 -->
+    <!-- crystal structure -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000102">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000102">
         <rdfs:label>crystal structure</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000101"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000101"/>
         <dc:description>A crystal structure is a chemical substance quality which inheres in a crystalline solid or liquid crystal substance by virtue of the way the molecules are ordered within the crystal.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000103 -->
+    <!-- software module to calculate a chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000103">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000103">
         <rdfs:label>software module to calculate a chemical descriptor</rdfs:label>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000123"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000144"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000144"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A software module to calculate a chemical descriptor is software module that implements an algorithm which calculates a descriptor value for a chemical entity.</dc:description>
@@ -1737,15 +1717,15 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000104 -->
+    <!-- molecular QSAR descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000104">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000104">
         <rdfs:label>molecular QSAR descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000064"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000064"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A molecular QSAR descriptor is a OSAR descriptor which gives a quantitative value to some aspect of a molecular entity.</dc:description>
@@ -1753,49 +1733,49 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000105 -->
+    <!-- cycle basis -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000105">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000105">
         <rdfs:label>cycle basis</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <dc:description>The cycle basis of a molecular structure is the smallest set of cycles (closed paths) formed in the graph representation of the structure, from which all other cycles can be computed.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000106 -->
+    <!-- systematic name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000106">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000106">
         <rdfs:label>systematic name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <dc:description>A systematic name is a molecular entity name which is formulated systematically from the structure of the molecular entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000107 -->
+    <!-- IUPAC name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000107">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000107">
         <rdfs:label>IUPAC name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000106"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000106"/>
         <dc:description>An IUPAC name is a systematic name which is formulated according to the rules and recommendations for chemical nomenclature set out by the International Union of Pure and Applied Chemistry (IUPAC).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000108 -->
+    <!-- atomic quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000108">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000108">
         <rdfs:label>atomic quality</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty>
                     <rdf:Description>
-                        <owl:inverseOf rdf:resource="&OBO_REL;bearer_of"/>
+                        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
                     </rdf:Description>
                 </owl:onProperty>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An atomic quality is a molecular entity quality which inheres in an atom.</dc:description>
@@ -1803,25 +1783,25 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000109 -->
+    <!-- trivial name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000109">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000109">
         <rdfs:label>trivial name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <dc:description>A trivial name is a molecular entity name that is in common public use and may not be related to the structure of the molecular entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000110 -->
+    <!-- fused cycles -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000110">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000110">
         <rdfs:label>fused cycles</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The fused cycles in a molecular structure are those cycles from the cycle basis which share at least one bond.</dc:description>
@@ -1829,25 +1809,25 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000111 -->
+    <!-- CML format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000111">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000111">
         <rdfs:label>CML format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000035"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000035"/>
         <dc:description>A CML (Chemical Markup Language) file is an XML-based representation of the atomic connectivity of a molecular entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000112 -->
+    <!-- atomic QSAR descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000112">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000112">
         <rdfs:label>atomic QSAR descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000064"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000064"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An atomic QSAR descriptor is a QSAR descriptor which gives a quantitative value to some aspect of an atom which is part of a molecular entity.</dc:description>
@@ -1855,21 +1835,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000113 -->
+    <!-- InChI descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000113">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000113">
         <rdfs:label>InChI descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000038"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000038"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An InChI descriptor is a structure descriptor which conforms to the InChI format specification.</dc:description>
@@ -1877,21 +1857,21 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000114 -->
+    <!-- MOLfile descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000114">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000114">
         <rdfs:label>MOLfile descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000100"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000100"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A MOLfile descriptor is a structure descriptor which conforms to the MOLfile format specification.</dc:description>
@@ -1899,25 +1879,25 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000115 -->
+    <!-- aromaticity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000115">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000115">
         <rdfs:label>aromaticity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Aromaticity is a molecular entity quality that inheres in a conjugated ring of unsaturated bonds, lone pairs, or empty orbitals that exhibit a stabilization stronger than would be expected by the stabilization of conjugation alone.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000116 -->
+    <!-- atomic connectivity index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000116">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000116">
         <rdfs:label>atomic connectivity index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An atomic connectivity index is an atomic descriptor that is a measure of atomic connectivity, which can take various forms (e.g. zero-order, or first-order).</dc:description>
@@ -1925,25 +1905,25 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000117 -->
+    <!-- Wiener path number -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000117">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000117">
         <rdfs:label>Wiener path number</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Half the sum of all the distance matrix entries, topological index of atom-atom distances.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000118 -->
+    <!-- formal charge descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000118">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000118">
         <rdfs:label>formal charge descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000131"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000131"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The formal charge gives the charge assigned to an atom in a molecule, assuming that electrons in a chemical bond are shared equally between atoms, regardless of relative electronegativity.
@@ -1952,15 +1932,15 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000119 -->
+    <!-- partial charge descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000119">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000119">
         <rdfs:label>partial charge descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000131"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000131"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A partial charge descriptor gives the charge with an absolute value of less than one elementary charge unit (that is, smaller than the charge of the electron). [source:wikipedia]</dc:description>
@@ -1968,40 +1948,40 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000120 -->
+    <!-- charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000120">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000120">
         <rdfs:label>charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Charge is a quality that inheres in a molecular entity by virtue of the overall electric charge of the molecule, which is due to a comparison between the total number of electrons and the total number of protons.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000121 -->
+    <!-- electronegativity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000121">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000121">
         <rdfs:label>electronegativity</rdfs:label>
         <dc:description>Electronegativity is an atomic quality that describes its power to attract electrons to itself [source:IUPAC Gold Book - http://goldbook.iupac.org/E01990.html]</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000122 -->
+    <!-- electronegativity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000122">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000122">
         <rdfs:label>electronegativity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000121"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000121"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>An electronegativity descriptor is a chemical descriptor that is about the electronegativity quality of an atom.</dc:description>
@@ -2009,28 +1989,28 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000123 -->
+    <!-- chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000123">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000123">
         <rdfs:label>chemical descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000086"/>
-                            <rdf:Description rdf:about="&resource;CHEMINF_000404"/>
-                        </owl:unionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000000"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000086"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000404"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A chemical descriptor is a data item (quantity or value) about a chemical entity that conforms to a specification for how it is calculated, measured or recorded.</dc:description>
@@ -2038,78 +2018,78 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000124 -->
+    <!-- radius -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000124">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000124">
         <rdfs:label>radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;PATO_0001708"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001708"/>
         <dc:description>A 1-D extent quality inhering in a bearer by virtue of the bearer&apos;s  dimension of extension to the circumference of a circle or sphere.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000125 -->
+    <!-- atomic radius -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000125">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000125">
         <rdfs:label>atomic radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000124"/>
         <rdfs:comment>Atomic radius is the 1D extent of the electron cloud surrounding the atom.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000124"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000126 -->
+    <!-- ionic radius -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000126">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000126">
         <rdfs:label>ionic radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000124"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000124"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000127 -->
+    <!-- van der Waals radius -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000127">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000127">
         <rdfs:label>van der Waals radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000125"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000125"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000128 -->
+    <!-- covalent radius -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000128">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000128">
         <rdfs:label>covalent radius</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000125"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000125"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000129 -->
+    <!-- bond multiplicity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000129">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000129">
         <rdfs:label>bond multiplicity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>Bond multiplicity is the extent to which participating electrons are localized in the bonding orbitals.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000130 -->
+    <!-- bond multiplicity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000130">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000130">
         <rdfs:label>bond multiplicity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000129"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000129"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A bond multiplicity descriptor is a chemical descriptor that in primitive cases is defined as half of the difference between the number of bonding and antibonding electrons in a particular system, but may also be defined with relation to the strength of a single bond.</dc:description>
@@ -2117,21 +2097,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000131 -->
+    <!-- charge descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000131">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000131">
         <rdfs:label>charge descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000120"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000120"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A charge descriptor is a chemical descriptor which indicates the charge of a chemical entity.</dc:description>
@@ -2139,21 +2119,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000132 -->
+    <!-- bond length descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000132">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000132">
         <rdfs:label>bond length descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000060"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000060"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&obo;PATO_0000122"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000122"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A bond length descriptor is a dimensional extent descriptor which gives the measured or predicted (idealised) length of an atom to atom bond within a chemical entity.</dc:description>
@@ -2161,616 +2141,616 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000133 -->
+    <!-- sp hybridized -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000133">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000133">
         <rdfs:label>sp hybridized</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000091"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000091"/>
         <dc:description>The quality of an atom in which the 2s orbital mixes with only one of the three p-orbitals resulting in two sp orbitals and two remaining unchanged p orbitals. spsp overlap between two atoms form a s bond and two additional p bonds formed by pp overlap.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000134 -->
+    <!-- sp2 hybridized -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000134">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000134">
         <rdfs:label>sp2 hybridized</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000091"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000091"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000135 -->
+    <!-- sp3 hybridized -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000135">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000135">
         <rdfs:label>sp3 hybridized</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000091"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000091"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000136 -->
+    <!-- constitutional descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000136">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000136">
         <rdfs:label>constitutional descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000137 -->
+    <!-- Wiener polarity number descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000137">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000137">
         <rdfs:label>Wiener polarity number descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Half the sum of all the distance matrix entries with a value of 3</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000138 -->
+    <!-- software execution -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000138">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000138">
         <rdfs:label>software execution</rdfs:label>
         <rdfs:comment>software execution is a process in which the instruction set that comprises the software program is executed on a machine.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000144 -->
+    <!-- algorithm to calculate a chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000144">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000144">
         <rdfs:label>algorithm to calculate a chemical descriptor</rdfs:label>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000123"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000146 -->
+    <!-- topological surface area descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000146">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000146">
         <rdfs:label>topological surface area descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000147 -->
+    <!-- parameterized software execution -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000147">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000147">
         <rdfs:label>parameterized software execution</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000138"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000138"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000149 -->
+    <!-- generic SMILES descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000149">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000149">
         <rdfs:label xml:lang="en">generic SMILES descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000018"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000018"/>
         <dc:description>a generic SMILES descriptor is a SMILES descriptor that denotes only the labeled molecular graph (i.e. atoms and bonds, but no chiral or isotopic information).</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000150 -->
+    <!-- isomeric SMILES format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000150">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000150">
         <rdfs:label>isomeric SMILES format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000020"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000020"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000151 -->
+    <!-- canonical SMILES format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000151">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000151">
         <rdfs:label>canonical SMILES format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000150"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000150"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000152 -->
+    <!-- topological polar surface area descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000152">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000152">
         <rdfs:label>topological polar surface area descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000146"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000146"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000153 -->
+    <!-- charge weighted partial negative surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000153">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000153">
         <rdfs:label>charge weighted partial negative surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>charge weighted partial negative surface area</dc:description>
         <short_name>PNSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000154 -->
+    <!-- DPSA-1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000154">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000154">
         <rdfs:label>DPSA-1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>difference of PPSA-1 and PNSA-1</dc:description>
         <short_name>DPSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000155 -->
+    <!-- DPSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000155">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000155">
         <rdfs:label>DPSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>DPSA-2</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>difference of FPSA-2 and PNSA-2</dc:description>
+        <short_name>DPSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000156 -->
+    <!-- DPSA-3 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000156">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000156">
         <rdfs:label>DPSA-3</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>difference of PPSA-3 and PNSA-3</dc:description>
         <short_name>DPSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000157 -->
+    <!-- FPSA-1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000157">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000157">
         <rdfs:label>FPSA-1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>FPSA-1</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-1 / total molecular surface area</dc:description>
+        <short_name>FPSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000158 -->
+    <!-- FPSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000158">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000158">
         <rdfs:label>FPSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-2 / total molecular surface area</dc:description>
         <short_name>FPSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000159 -->
+    <!-- FPSA-3 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000159">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000159">
         <rdfs:label>FPSA-3</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-3 / total molecular surface area</dc:description>
         <short_name>FPSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000160 -->
+    <!-- FNSA-1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000160">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000160">
         <rdfs:label>FNSA-1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>FNSA-1</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-1 / total molecular surface area</dc:description>
+        <short_name>FNSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000161 -->
+    <!-- FNSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000161">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000161">
         <rdfs:label>FNSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-2 / total molecular surface area</dc:description>
         <short_name>FNSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000162 -->
+    <!-- FNSA-3 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000162">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000162">
         <rdfs:label>FNSA-3</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-3 / total molecular surface area</dc:description>
         <short_name>FNSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000163 -->
+    <!-- WPSA-1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000163">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000163">
         <rdfs:label>WPSA-1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>WPSA-1</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-1 * total molecular surface area / 1000</dc:description>
+        <short_name>WPSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000164 -->
+    <!-- WPSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000164">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000164">
         <rdfs:label>WPSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-2 * total molecular surface area /1000</dc:description>
         <short_name>WPSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000165 -->
+    <!-- WPSA-3 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000165">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000165">
         <rdfs:label>WPSA-3</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>WPSA-3</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PPSA-3 * total molecular surface area /1000</dc:description>
+        <short_name>WPSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000166 -->
+    <!-- WNSA-1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000166">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000166">
         <rdfs:label>WNSA-1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>WNSA-1</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-1 * total molecular surface area /1000</dc:description>
+        <short_name>WNSA-1</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000167 -->
+    <!-- WNSA-2 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000167">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000167">
         <rdfs:label>WNSA-2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-2 * total molecular surface area /1000</dc:description>
         <short_name>WNSA-2</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000168 -->
+    <!-- WNSA-3 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000168">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000168">
         <rdfs:label>WNSA-3</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>PNSA-3 * total molecular surface area /1000</dc:description>
         <short_name>WNSA-3</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000169 -->
+    <!-- relative positive charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000169">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000169">
         <rdfs:label>relative positive charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>RPCG</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>most positive charge / total positive charge</dc:description>
+        <short_name>RPCG</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000170 -->
+    <!-- relative negative charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000170">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000170">
         <rdfs:label>relative negative charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>RNCG</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>most negative charge / total negative charge</dc:description>
+        <short_name>RNCG</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000171 -->
+    <!-- relative positive charge surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000171">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000171">
         <rdfs:label>relative positive charge surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>most positive surface area * RPCG</dc:description>
         <short_name>RPCS</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000172 -->
+    <!-- relative negative charge surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000172">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000172">
         <rdfs:label>relative negative charge surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>RNCS</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>most negative surface area * RNCG</dc:description>
+        <short_name>RNCS</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000173 -->
+    <!-- THSA -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000173">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000173">
         <rdfs:label>THSA</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>THSA</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>sum of solvent accessible surface areas of atoms with absolute value of partial charges less than 0.2</dc:description>
+        <short_name>THSA</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000174 -->
+    <!-- TPSA -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000174">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000174">
         <rdfs:label>TPSA</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>TPSA</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>sum of solvent accessible surface areas of atoms with absolute value of partial charges greater than or equal 0.2</dc:description>
+        <short_name>TPSA</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000175 -->
+    <!-- RHSA -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000175">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000175">
         <rdfs:label>RHSA</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>THSA / total molecular surface area</dc:description>
         <short_name>RHSA</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000176 -->
+    <!-- RPSA -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000176">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000176">
         <rdfs:label>RPSA</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
-        <short_name>RPSA</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
         <dc:description>TPSA / total molecular surface area</dc:description>
+        <short_name>RPSA</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000177 -->
+    <!-- collection of 3D coordinates -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000177">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000177">
         <rdfs:label>collection of 3D coordinates</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000178 -->
+    <!-- collection of 3D atomic coordinates -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000178">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000178">
         <rdfs:label>collection of 3D atomic coordinates</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000177"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000177"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_proper_part"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000403"/>
+                <owl:onProperty rdf:resource="http://www.obofoundry.org/ro/ro.owl#has_proper_part"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000403"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000179 -->
+    <!-- molecular polarizability -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000179">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000179">
         <rdfs:label xml:lang="en">molecular polarizability</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
-        <short_name>BPol</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
         <dc:description>Sum of the absolute value of the difference between atomic polarizabilities of all bonded atoms in the molecule (including implicit hydrogens)</dc:description>
+        <short_name>BPol</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000180 -->
+    <!-- fragment complexity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000180">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000180">
         <rdfs:label xml:lang="en">fragment complexity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000219"/>
-        <short_name>FragmentComplexity</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000219"/>
         <dc:description>defined as @cdk.cite{Nilakantan06}</dc:description>
+        <short_name>FragmentComplexity</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000181 -->
+    <!-- vertex adjacency matrix descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000181">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000181">
         <rdfs:label xml:lang="en">vertex adjacency matrix descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000182 -->
+    <!-- Petitjean Topological Shape Index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000182">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000182">
         <rdfs:label xml:lang="en">Petitjean Topological Shape Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000185"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000185"/>
         <dc:description>A measure of the anisotropy in a molecule (as per Petitjean et al)</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000183 -->
+    <!-- Petitjean Geometric Shape Index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000183">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000183">
         <rdfs:label xml:lang="en">Petitjean Geometric Shape Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000185"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000185"/>
         <dc:description>A measure of the anisotropy in a molecule (as per Bath et al)</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000184 -->
+    <!-- Petitjean number -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000184">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000184">
         <rdfs:label xml:lang="en">Petitjean number</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>the eccentricity of a vertex corresponds to the distance from that vertex to the most remote vertex in the graph. The distance is obtained from the distance matrix as the count of edges between the two vertices. If r i is the largest matrix entry in row i of the distance matrix D, then the radius is defined as the smallest of the r i . The graph diameter D is defined as the largest vertex eccentricity in the graph. Petitjean Number is the value of ( diameter - radius ) diameter .</dc:description>
         <short_name>petitjeanNumber</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000185 -->
+    <!-- Petitjean Shape Index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000185">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000185">
         <rdfs:label xml:lang="en">Petitjean Shape Index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>A measure of the anisotropy in a molecule</dc:description>
         <short_name>petitjeanShapeIndex</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000186 -->
+    <!-- XLogP descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000186">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000186">
         <rdfs:label xml:lang="en">XLogP descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000251"/>
-        <short_name>XLogP</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000251"/>
         <dc:description>A LogP descriptor based on the atom-type method described in Wang, R., Fu, Y., and Lai, L.. A New Atom-Additive Method for Calculating Partition Coefficients, Journal of Chemical Information and Computer Sciences. vol. 37. 1997, pp. 615-621.</dc:description>
+        <short_name>XLogP</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000187 -->
+    <!-- MLogP descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000187">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000187">
         <rdfs:label xml:lang="en">MLogP descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000251"/>
-        <short_name>MannholdLogP</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000251"/>
         <dc:description>A LogP descriptor based on a simple equation using the number of carbons and hetero atoms.</dc:description>
+        <short_name>MannholdLogP</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000188 -->
+    <!-- maximal ratio of length to breadth descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000188">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000188">
         <rdfs:label xml:lang="en">maximal ratio of length to breadth descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000189"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000189"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000189 -->
+    <!-- ratio of length to breadth descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000189">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000189">
         <rdfs:label xml:lang="en">ratio of length to breadth descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000190 -->
+    <!-- minimal ratio of length to breadth descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000190">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000190">
         <rdfs:label xml:lang="en">minimal ratio of length to breadth descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000189"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000189"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000191 -->
+    <!-- ionization energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000191">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000191">
         <rdfs:label xml:lang="en">ionization energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000094"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000094"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000192 -->
+    <!-- eccentric connectivity index descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000192">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000192">
         <rdfs:label xml:lang="en">eccentric connectivity index descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <short_name>EccentricConnectivityIndex</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000193 -->
+    <!-- equilibrium constant -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000193">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000193">
         <rdfs:label xml:lang="en">equilibrium constant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000194 -->
+    <!-- acid dissociation constant -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000194">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000194">
         <rdfs:label xml:lang="en">acid dissociation constant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000193"/>
-        <short_name>Ka</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000193"/>
         <dc:description>the acid dissociation constant, Ka, is quantitative measure of the strength of an acid in solution. It is the equilibrium constant for a chemical reaction known as dissociation in the context of acid-base reactions.</dc:description>
+        <short_name>Ka</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000195 -->
+    <!-- pKa -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000195">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000195">
         <rdfs:label xml:lang="en">pKa</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000193"/>
-        <short_name>pKa</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000193"/>
         <dc:description>the logarithmic measure of the acid dissociation constant (Ka)</dc:description>
+        <short_name>pKa</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000196 -->
+    <!-- cycle -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000196">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000196">
         <rdfs:label>cycle</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000197"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000197"/>
         <dc:description>A cycle is a part of a molecular entity that is cyclic, that is, consists of a chain of atoms where each is reachable by a bond connected to another atom, and the first atom is reachable from itself.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000197 -->
+    <!-- substructure -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000197">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000197">
         <rdfs:label>substructure</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000000"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_proper_part"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://www.obofoundry.org/ro/ro.owl#has_proper_part"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A substructure is a contiguous part of a molecule composed of at least two atoms and a bond.</dc:description>
@@ -2778,241 +2758,241 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000199 -->
+    <!-- absolute SMILES descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000199">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000199">
         <rdfs:label xml:lang="en">absolute SMILES descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000032"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000032"/>
         <dc:description>An absolute SMILES descriptor is an isomeric SMILES descriptor that is produced using a canonicalization algorithm. </dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000202 -->
+    <!-- tautomer count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000202">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000202">
         <rdfs:label xml:lang="en">tautomer count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <dc:description>a count descriptor that denotes the number of tautomers.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000203 -->
+    <!-- stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000203">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000203">
         <rdfs:label xml:lang="en">stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000205 -->
+    <!-- atom stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000205">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000205">
         <rdfs:label xml:lang="en">atom stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000203"/>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000213"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000203"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000213"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000206 -->
+    <!-- defined atom stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000206">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000206">
         <rdfs:label xml:lang="en">defined atom stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000205"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000205"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000207 -->
+    <!-- formation energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000207">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000207">
         <rdfs:label>formation energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000016"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000016"/>
         <dc:description>A formation energy descriptor is an energetic descriptor which gives the value for the energy of formation of a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000208 -->
+    <!-- solvation energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000208">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000208">
         <rdfs:label>solvation energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000016"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000016"/>
         <dc:description>A solvation energy descriptor is a chemical descriptor which gives the value for the energy of dissolving a particular chemical entity in a solvent.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000209 -->
+    <!-- count descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000209">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000209">
         <rdfs:label>count descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>A count descriptor is a chemical descriptor which is calculated by counting the number of features of a certain kind which are present in the chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000210 -->
+    <!-- dissociation energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000210">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000210">
         <rdfs:label>dissociation energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000016"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000016"/>
         <dc:description>A dissociation energy descriptor is an energetic descriptor which gives a value for the dissociation energy for a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000211 -->
+    <!-- dimensional extent quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000211">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000211">
         <rdfs:label>dimensional extent quality</rdfs:label>
         <dc:description>A dimensional extent quality is a quality that inheres in a molecular entity by virtue of a measurement of length, area or volume in a one, two or three dimensional extent.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000212 -->
+    <!-- undefined atom stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000212">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000212">
         <rdfs:label xml:lang="en">undefined atom stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000205"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000205"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000213 -->
+    <!-- bond stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000213">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000213">
         <rdfs:label xml:lang="en">bond stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000203"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000203"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000214 -->
+    <!-- defined bond stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000214">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000214">
         <rdfs:label xml:lang="en">defined bond stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000213"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000213"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000215 -->
+    <!-- undefined bond stereocenter count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000215">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000215">
         <rdfs:label xml:lang="en">undefined bond stereocenter count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000213"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000213"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000216 -->
+    <!-- average molecular weight descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000216">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000216">
         <rdfs:label xml:lang="en">average molecular weight descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000088"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000088"/>
         <dc:description>The mass of a molecule calculated using the average mass of each element weighted for its natural isotopic abundance. E.g., Carbon has two natural isotopes 12 and 13 with relative abundances of 98.9% and 1.1% to yield an average mass of 12.011 g/mol</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000217 -->
+    <!-- exact mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000217">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000217">
         <rdfs:label xml:lang="en">exact mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000088"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000088"/>
         <dc:description>an exact mass descriptor corresponds to the mass of the most intense molecule/ion peak in an MS spec, and when calculated denotes the mass of an ion or a molecule containing most likely isotopic composition for a single random molecule.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000218 -->
+    <!-- monoisotopic mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000218">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000218">
         <rdfs:label xml:lang="en">monoisotopic mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000088"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000088"/>
         <dc:description>The mass of a molecule calculated using the mass of the most abundant isotope of each element. E.g., Carbon has a monoisotopic mass of 12.000 g/mol.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000219 -->
+    <!-- complexity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000219">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000219">
         <rdfs:label xml:lang="en">complexity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <dc:description>A complexity descriptor denotes the how complicated a structure is, seen from both the point of view of the elements contained and its structural features .</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000220 -->
+    <!-- cis-trans stereochemistry specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000220">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000220">
         <rdfs:label>cis-trans stereochemistry specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000028"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000028"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000222 -->
+    <!-- volume -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000222">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000222">
         <rdfs:label>volume</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000227"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000227"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000223 -->
+    <!-- pi-system size -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000223">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000223">
         <rdfs:label>pi-system size</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <short_name>LargestPiSystem</short_name>
         <dc:description>The integer number of atoms in a pi-orbital system.</dc:description>
+        <short_name>LargestPiSystem</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000224 -->
+    <!-- bond dissociation Gibbs energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000224">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000224">
         <rdfs:label>bond dissociation Gibbs energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000210"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000210"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000235"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000235"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Bond dissociation Gibbs energy descriptor captures the Gibbs energy associated with the process of breaking the bond in question. This could be measured or calculated in vacuo or in a specific Solvent, at a given temperature and pressure. Depends on molecular conformation.</dc:description>
@@ -3020,21 +3000,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000225 -->
+    <!-- solvation Gibbs energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000225">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000225">
         <rdfs:label>solvation Gibbs energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000208"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000208"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000258"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000258"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The molecular entity solvation Gibbs energy descriptor reflects the Gibbs energy associated with the solvation of the molecular entity in question. This could be measured or calculated in vacuo or in a specific solvent, at a particular temperature and pressure. Depends on molecular conformation when computed.</dc:description>
@@ -3042,55 +3022,55 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000226 -->
+    <!-- bond charge density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000226">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000226">
         <rdfs:label>bond charge density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000231"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000231"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000227 -->
+    <!-- 3-D extent -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000227">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000227">
         <rdfs:label>3-D extent</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000211"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000211"/>
         <dc:description>A three dimensional extent is a dimensional extent in three dimensions, e.g. a volume.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000228 -->
+    <!-- refractive index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000228">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000228">
         <rdfs:label>refractive index</rdfs:label>
         <dc:description>The refractive index of a chemical substance is a measure of the manner in which  light waves are bent when they enter the medium of the chemical substance.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000229 -->
+    <!-- surface area descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000229">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000229">
         <rdfs:label>surface area descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000060"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000060"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000247"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000247"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A surface area descriptor is a descriptor which describes a measure or calculation of the surface area of a chemical entity.</dc:description>
@@ -3098,31 +3078,31 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000230 -->
+    <!-- composition -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000230">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000230">
         <rdfs:label>composition</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
         <rdfs:comment>From PATO.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000231 -->
+    <!-- charge density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000231">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000231">
         <rdfs:label>charge density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000236"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000236"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A charge density descriptor is a chemical entity descriptor which indicates the distribution of the electric charge over the volume of the chemical entity.</dc:description>
@@ -3130,27 +3110,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000232 -->
+    <!-- aromatic atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000232">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000232">
         <rdfs:label>aromatic atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000263"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that provides the integer count of aromatic atoms in a given molecular entity.</dc:description>
@@ -3158,27 +3138,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000233 -->
+    <!-- bond count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000233">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000233">
         <rdfs:label>bond count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that specifies the integer count of bonds in a given molecular entity.</dc:description>
@@ -3186,49 +3166,49 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000234 -->
+    <!-- PubChem conformer identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000234">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000234">
         <rdfs:label xml:lang="en">PubChem conformer identifier</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000235 -->
+    <!-- disposition to dissociate -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000235">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000235">
         <rdfs:label>disposition to dissociate</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
         <dc:description>The disposition to dissociate is the disposition of an ionic compound (complexes, or salts) to separate or split into smaller particles, ions, or radicals, usually in a reversible manner.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000236 -->
+    <!-- charge density -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000236">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000236">
         <rdfs:label>charge density</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000031"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000031"/>
         <dc:description>The linear, surface, or volume charge density is the amount of electric charge in a line, surface, or volume  respectively. [source: Wikipedia, http://en.wikipedia.org/wiki/Charge_density]</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000237 -->
+    <!-- bond aromaticity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000237">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000237">
         <rdfs:label>bond aromaticity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000056"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000056"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000115"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000115"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A bond aromaticity descriptor is an aromaticity descriptor associated with a bond within a chemical entity which indicates whether that  bond belongs to an aromatic system.</dc:description>
@@ -3236,30 +3216,30 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000238 -->
+    <!-- meltability -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000238">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000238">
         <rdfs:label>meltability</rdfs:label>
         <dc:description>The meltability of a chemical substance is a quality which inheres in the chemical substance by virtue of the ease with which the substance can be changed from a solid to a liquid state especially by the application of heat.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000239 -->
+    <!-- formation Gibbs energy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000239">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000239">
         <rdfs:label>formation Gibbs energy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000207"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000207"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000259"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000259"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The formation Gibbs energy descriptor captures the Gibbs energy associated with the formation of a molecular entity, relative to the standard state of constituent atoms. This can be measured, calculated in vacuo, or calculated with respect to a specific solvent, at a particular temperature and pressure. When calculated, the formation Gibbs energy value depends on the molecular conformation.</dc:description>
@@ -3267,27 +3247,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000240 -->
+    <!-- size of largest aliphatic chain -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000240">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000240">
         <rdfs:label>size of largest aliphatic chain</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000246"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000246"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The largest aliphatic chain size descriptor is a count descriptor that gives the integer length (number of atoms) in the largest unbranched chain of atoms that does not contain aromatic atoms, within a given molecular entity.</dc:description>
@@ -3295,21 +3275,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000241 -->
+    <!-- formation enthalpy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000241">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000241">
         <rdfs:label>formation enthalpy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000207"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000207"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000259"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000259"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Molecular entity formation enthaply descriptor captures the enthalpy associated with the formation of the molecular entity in question, relative to the standard state of constituent atoms. This could be measured or calculated in vacuo or in a specific Solvent, at a particular temperature and pressure. Depends on molecular conformation when computed.</dc:description>
@@ -3317,21 +3297,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000242 -->
+    <!-- volume descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000242">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000242">
         <rdfs:label>volume descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000060"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000060"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000222"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000222"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A volume descriptor is a descriptor which describes a measure or calculation of the volume of a chemical entity.</dc:description>
@@ -3339,27 +3319,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000243 -->
+    <!-- aromatic bond count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000243">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000243">
         <rdfs:label>aromatic bond count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000233"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000233"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that provides the integer count of aromatic bonds in a given molecular entity.</dc:description>
@@ -3367,27 +3347,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000244 -->
+    <!-- hydrogen bond donor count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000244">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000244">
         <rdfs:label>hydrogen bond donor count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that reflects the integer number of hydrogen bond donors in a given molecular entity, as determined by a given method. In highly simplified terms, this is usually the count of all negatively or partially negatively charged heteroatoms (e.g. alcohol oxygen) that have covalently attached to them partially positively charged hydrogen atoms that are capable of participating in a hydrogen bond.</dc:description>
@@ -3395,21 +3375,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000245 -->
+    <!-- hydrogen bond acceptor count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000245">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000245">
         <rdfs:label>hydrogen bond acceptor count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that reflects the integer number of hydrogen bond acceptors in a given molecular entity, as determined by a given method. In highly simplified terms, this is usually the count of all negatively or partially negatively charged heteroatoms (e.g. alcohol oxygen) capable of accepting a hydrogen bond.</dc:description>
@@ -3417,27 +3397,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000246 -->
+    <!-- size of largest chain -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000246">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000246">
         <rdfs:label>size of largest chain</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The largest chain size descriptor is a count descriptor that gives the integer length (number of atoms) in the largest chain in a molecular entity.</dc:description>
@@ -3445,39 +3425,39 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000247 -->
+    <!-- surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000247">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000247">
         <rdfs:label>surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000262"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000262"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000248 -->
+    <!-- relative permittivity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000248">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000248">
         <rdfs:label>relative permittivity</rdfs:label>
         <dc:description>Relative permittivity is a chemical substance quality that reflects the ability of a medium composed of molecules of a given type to transmit an electric field.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000249 -->
+    <!-- solvation entropy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000249">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000249">
         <rdfs:label>solvation entropy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000208"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000208"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000258"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000258"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The molecular entity solvation entropy descriptor reflects the entropy associated with the solvation of the molecular entity in question. This could be measured or calculated in vacuo or in a specific solvent, at a particular temperature and pressure. Depends on molecular conformation when computed.</dc:description>
@@ -3485,21 +3465,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000250 -->
+    <!-- solvation enthalpy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000250">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000250">
         <rdfs:label>solvation enthalpy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000208"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000208"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000258"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000258"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The molecular entity solvation enthalpy descriptor reflects the enthalpy associated with the solvation of the molecular entity in question. This could be measured or calculated in vacuo or in a specific solvent, at a particular temperature and pressure. Depends on molecular conformation when computed.</dc:description>
@@ -3507,21 +3487,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000251 -->
+    <!-- logP descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000251">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000251">
         <rdfs:label>logP descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000258"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000258"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The logarithm of octanol-water partition coefficient, which is the ratio of the molecules dissolved in octanol to those dissolved in pure un-ionized water upon mixture equilibration. This can be measured or predicted. The value is dimensionless. May depend on molecular conformation when computed.</dc:description>
@@ -3529,21 +3509,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000252 -->
+    <!-- bond dissociation enthalpy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000252">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000252">
         <rdfs:label>bond dissociation enthalpy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000210"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000210"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000235"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000235"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Bond dissociation enthalpy descriptor captures the enthalpy associated with the process of breaking the bond in question. This could be measured or calculated in vacuo or in a specific Solvent, at a given temperature and pressure. Depends on molecular conformation.</dc:description>
@@ -3551,21 +3531,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000253 -->
+    <!-- refractive index descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000253">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000253">
         <rdfs:label>refractive index descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000228"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000228"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Chemical substance refractive index descriptor is a unitless descriptor that specifies the ratio of the speed of light in vacuum to that in a given chemical substance. [IUPAC: http://goldbook.iupac.org/R05240.html]</dc:description>
@@ -3573,122 +3553,122 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000254 -->
+    <!-- rotatable bond count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000254">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000254">
         <rdfs:label>rotatable bond count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000233"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000233"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <short_name>RotatableBondsCount</short_name>
         <dc:description>a bond count that denotes the integer number of rotors in the molecule, generally single bonds torsion around which produces non-identical geometric molecular configurations.</dc:description>
+        <short_name>RotatableBondsCount</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000255 -->
+    <!-- vaporizability -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000255">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000255">
         <rdfs:label>vaporizability</rdfs:label>
         <dc:description>The vaporizability of a chemical substance is a quality which inheres in the chemical substance by virtue of the ease with which the substance can be changed into a gaseous state.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000256 -->
+    <!-- melting point descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000256">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000256">
         <rdfs:label>melting point descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000238"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment>Melting point descriptor specifies the temperature at which a chemical substance undergoes the transition from solid to liquid state under standard conditions.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000238"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000257 -->
+    <!-- boiling point descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000257">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000257">
         <rdfs:label>boiling point descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000255"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment>The boiling point descriptor indicates the temperature at which a chemical substance undergoes a state transition from liquid to gas, at standard conditions.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000255"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000258 -->
+    <!-- solubility -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000258">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000258">
         <rdfs:label>solubility</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000259 -->
+    <!-- disposition to form -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000259">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000259">
         <rdfs:label>disposition to form</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
         <dc:description>The disposition to form is the disposition of an ionic compound (complexes, or salts) to form from the smaller particles, ions, or radicals from which it is constituted.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000260 -->
+    <!-- formation entropy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000260">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000260">
         <rdfs:label>formation entropy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000207"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000207"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000259"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000259"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Molecular entity formaiton entropy descriptor captures the entropy associated with the formation of the molecular entity in question, relative to the standard state of constituent atoms. This could be measured or calculated in vacuo or in a specific Solvent, at a particular temperature and pressure. Depends on molecular conformation when computed.</dc:description>
@@ -3696,21 +3676,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000261 -->
+    <!-- relative permittivity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000261">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000261">
         <rdfs:label>relative permittivity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000248"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000248"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The relative permittivity descriptor specifies the ratio of the electric field strength in vacuum to that in a given medium. It was formerly called the dielectric constant. [IUPAC Gold Book: http://goldbook.iupac.org/R05273.html ]</dc:description>
@@ -3718,37 +3698,37 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000262 -->
+    <!-- 2-D extent -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000262">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000262">
         <rdfs:label>2-D extent</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000211"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000211"/>
         <dc:description>A two dimensional extent is a dimensional extent in two dimensions, e.g. an area.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000263 -->
+    <!-- atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000263">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000263">
         <rdfs:label>atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that specifies the integer count of atoms in a given molecular entity.</dc:description>
@@ -3756,36 +3736,36 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000264 -->
+    <!-- atomic charge density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000264">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000264">
         <rdfs:label>atomic charge density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000231"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000231"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_33250"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000265 -->
+    <!-- bond dissociation entropy descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000265">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000265">
         <rdfs:label>bond dissociation entropy descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000210"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000210"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000063"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000235"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000235"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Bond dissociation entropy descriptor captures the entropy associated with the process of breaking the bond in question. This could be measured or calculated in vacuo or in a specific Solvent, at a given temperature and pressure. Depends on molecular conformation.</dc:description>
@@ -3793,35 +3773,35 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000266 -->
+    <!-- chemical substance -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000266">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000266">
         <rdfs:label>chemical substance</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000000"/>
         <rdfs:comment>Chemical substance constitutes matter of constant composition, that may contain a collection of molecular entities. [IUPAC: http://goldbook.iupac.org/C01039.html]</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000267 -->
+    <!-- effective rotor count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000267">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000267">
         <rdfs:label xml:lang="en">effective rotor count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <dc:description>A count descriptor that takes into account flexibility of rings and rotatable bonds.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000268 -->
+    <!-- total formal charge descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000268">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000268">
         <rdfs:label xml:lang="en">total formal charge descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000131"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000131"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A charge descriptor that gives the total charge for a molecule</dc:description>
@@ -3829,223 +3809,223 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000269 -->
+    <!-- conformer volume descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000269">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000269">
         <rdfs:label xml:lang="en">conformer volume descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000242"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000242"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000270 -->
+    <!-- amino acid count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000270">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000270">
         <rdfs:label>amino acid count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <dc:description>a count of the number of amino acid residues.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000271 -->
+    <!-- alanine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000271">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000271">
         <rdfs:label>alanine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000272 -->
+    <!-- arginine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000272">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000272">
         <rdfs:label>arginine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000273 -->
+    <!-- asparagine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000273">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000273">
         <rdfs:label>asparagine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000274 -->
+    <!-- aspartate count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000274">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000274">
         <rdfs:label>aspartate count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000275 -->
+    <!-- cysteine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000275">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000275">
         <rdfs:label>cysteine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000276 -->
+    <!-- phenylalanine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000276">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000276">
         <rdfs:label>phenylalanine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000277 -->
+    <!-- glutamate count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000277">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000277">
         <rdfs:label>glutamate count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000278 -->
+    <!-- glutamine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000278">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000278">
         <rdfs:label>glutamine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000279 -->
+    <!-- glycine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000279">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000279">
         <rdfs:label>glycine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000280 -->
+    <!-- histidine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000280">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000280">
         <rdfs:label xml:lang="en">covalent unit count</rdfs:label>
         <rdfs:label>histidine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
         <dc:description>The number of covalent units (molecule / ion) in a chemical structure</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000281 -->
+    <!-- isoleucine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000281">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000281">
         <rdfs:label>isoleucine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000282 -->
+    <!-- proline count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000282">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000282">
         <rdfs:label>proline count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000283 -->
+    <!-- leucine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000283">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000283">
         <rdfs:label>leucine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000284 -->
+    <!-- lysine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000284">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000284">
         <rdfs:label>lysine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000285 -->
+    <!-- methionine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000285">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000285">
         <rdfs:label>methionine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000286 -->
+    <!-- serine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000286">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000286">
         <rdfs:label>serine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000287 -->
+    <!-- threonine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000287">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000287">
         <rdfs:label>threonine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000288 -->
+    <!-- tyrosine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000288">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000288">
         <rdfs:label>tyrosine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000289 -->
+    <!-- valine count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000289">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000289">
         <rdfs:label>valine count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000290 -->
+    <!-- tryptophan count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000290">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000290">
         <rdfs:label>tryptophan count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000270"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000270"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000291 -->
+    <!-- Highest Occupied Molecular Orbital Energy -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000291">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000291">
         <rdfs:label>Highest Occupied Molecular Orbital Energy</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000000"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000086"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000086"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that the energy of the highest occupied &apos;molecular&apos; orbital of the chemical entity.</dc:description>
@@ -4053,21 +4033,21 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000292 -->
+    <!-- Lowest Unoccupied Molecular Orbital Energy -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000292">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000292">
         <rdfs:label>Lowest Unoccupied Molecular Orbital Energy</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000086"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000000"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000000"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000086"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that the energy of the lowest unoccupied &apos;molecular&apos; orbital of the chemical entity.</dc:description>
@@ -4075,27 +4055,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000293 -->
+    <!-- acidic group count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000293">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000293">
         <rdfs:label>acidic group count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that specifies the integer count of acidic groups in a given molecular entity.</dc:description>
@@ -4103,27 +4083,27 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000294 -->
+    <!-- basic group count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000294">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000294">
         <rdfs:label>basic group count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000230"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;int"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that specifies the integer count of basic groups in a given molecular entity.</dc:description>
@@ -4131,230 +4111,223 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000295 -->
+    <!-- ALogP descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000295">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000295">
         <rdfs:label xml:lang="en">ALogP descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000251"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000251"/>
         <dc:description>The ALogP descriptor described by Ghose and Crippen in 1986 and 1987.</dc:description>
         <short_name>ALogP</short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000296 -->
+    <!-- hybridization descriptor (VSEPR) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000296">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000296">
         <rdfs:label xml:lang="en">hybridization descriptor (VSEPR)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000095"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000095"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000297 -->
+    <!-- inductive atomic hardness -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000297">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000297">
         <rdfs:label xml:lang="en">inductive atomic hardness</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000298 -->
+    <!-- TPSA (fragments) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000298">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000298">
         <rdfs:label xml:lang="en">TPSA (fragments)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000152"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000152"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000299 -->
+    <!-- VABC volume descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000299">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000299">
         <rdfs:label xml:lang="en">VABC volume descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000242"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000242"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000300 -->
+    <!-- heavy atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000300">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000300">
         <rdfs:label xml:lang="en">heavy atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000263"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
         <dc:description>The number of non-hydrogen atoms</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000301 -->
+    <!-- isotope atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000301">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000301">
         <rdfs:label xml:lang="en">isotope atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000263"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
         <dc:description>The sum of all atoms enriched with respect to a particular atom isotope</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000302 -->
+    <!-- PubMed Identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000302">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000302">
         <rdfs:label xml:lang="en">PubMed Identifier</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000303 -->
+    <!-- GenBank Protein Identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000303">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000303">
         <rdfs:label xml:lang="en">GenBank Protein Identifier</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000304 -->
+    <!-- GenBank Nucleotide Identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000304">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000304">
         <rdfs:label xml:lang="en">GenBank Nucleotide Identifier</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000400 -->
+    <!-- chemical graph -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000400">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000400">
         <rdfs:label>chemical graph</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000085"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
         <dc:description>A chemical graph is a structural descriptor in which the connectivity and constitution of the chemical entity are described in terms of a mathematical graph, usually with atoms as vertices and bonds as edges, but other variants exist.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000401 -->
+    <!-- neutral charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000401">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000401">
         <rdfs:label>neutral charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000120"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000120"/>
         <dc:description>Neutral charge is a quality which inheres in a molecular entity by virtue of the molecular entity possessing the same amount of electrons overall as protons, thus having an overall neutral charge.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000402 -->
+    <!-- positive charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000402">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000402">
         <rdfs:label>positive charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000120"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000120"/>
         <dc:description>Positive charge is a quality which inheres in a molecular entity by virtue of the molecular entity possessing more protons overall than electrons, thus having an overall positive charge.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000403 -->
+    <!-- negative charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000403">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000403">
         <rdfs:label>negative charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000120"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000120"/>
         <dc:description>Negative charge is a quality which inheres in a molecular entity by virtue of the molecular entity possessing more electrons overall than protons, thus having an overall negative charge.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000404 -->
+    <!-- chemical disposition -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000404">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000404">
         <rdfs:label>chemical disposition</rdfs:label>
         <dc:description>A chemical disposition is a disposition which inheres in a chemical entity.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000405 -->
+    <!-- ChemSpider identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000405">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000405">
         <rdfs:label>ChemSpider identifier</rdfs:label>
         <dc:description>Database identifier used by ChemSpider.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000406 -->
+    <!-- DrugBank identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000406">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000406">
         <rdfs:label>DrugBank identifier</rdfs:label>
         <dc:description>Database identifier used by DrugBank.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000407 -->
+    <!-- ChEBI identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000407">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000407">
         <rdfs:label>ChEBI identifier</rdfs:label>
         <dc:description>Database identifier used by ChEBI.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000408 -->
+    <!-- HMDB identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000408">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000408">
         <rdfs:label>HMDB identifier</rdfs:label>
         <dc:description>Database identifier used by Human Metabolome Database.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000409 -->
+    <!-- KEGG identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000409">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000409">
         <rdfs:label>KEGG identifier</rdfs:label>
         <dc:description>Database identifier used by KEGG.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000410 -->
+    <!-- Wikipedia identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000410">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000410">
         <rdfs:label>Wikipedia identifier</rdfs:label>
         <dc:description>Database identifier used by Wikipedia.</dc:description>
     </owl:Class>
     
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000567 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000567">
-        <rdfs:label>Wikidata identifier</rdfs:label>
-        <dc:description>Database identifier used by Wikidata.</dc:description>
-    </owl:Class>
+    <!-- Reactome identifier -->
 
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000411 -->
-
-    <owl:Class rdf:about="&resource;CHEMINF_000411">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000411">
         <rdfs:label>Reactome identifier</rdfs:label>
         <dc:description>Database identifier used by Reactome.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000412 -->
+    <!-- ChEMBL identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000412">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000412">
         <rdfs:label>ChEMBL identifier</rdfs:label>
         <dc:description>Identifier used by the ChEMBL database for compounds, assays, target, etc.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000413 -->
+    <!-- organic carbon adsorption descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000413">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000413">
         <rdfs:label>organic carbon adsorption descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the ratio of the amount of a given chemical substance
     adsorbed per unit weight of organic carbon in soil or sediment to the concentration
@@ -4364,44 +4337,44 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000414 -->
+    <!-- bioconcentration factor descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000414">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000414">
         <rdfs:label>bioconcentration factor descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the ratio of the concentration of a chemical substance in an organism immersed in water to that in the surrounding water at equilibrium.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000415 -->
+    <!-- molar volume descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000415">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000415">
         <rdfs:label>molar volume descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the volume occupied by one mole of the given substance at a given temperature and pressure.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000416 -->
+    <!-- density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000416">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000416">
         <rdfs:label>density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
-        <dc:description>A descriptor of the density of a given substance at a given temperature and pressure.</dc:description>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>A descriptor of the density of a given substance at a given temperature and pressure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000417 -->
+    <!-- flash point descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000417">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000417">
         <rdfs:label>flash point descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the flash point of a substance at a given pressure.
     The flash point is the minimum temperature at which a mixture of the substance with air can be ignited, within its explosive range.</dc:description>
@@ -4409,87 +4382,87 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000418 -->
+    <!-- enthalpy of vaporization descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000418">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000418">
         <rdfs:label>enthalpy of vaporization descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the energy taken in by a chemical substance on vaporization at a given temperature and pressure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000419 -->
+    <!-- vapour pressure descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000419">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000419">
         <rdfs:label>vapour pressure descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the pressure exerted by the vapour phase of a chemical substance on its condensed phase at a given temperature and pressure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000420 -->
+    <!-- surface tension descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000420">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000420">
         <rdfs:label>surface tension descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>A descriptor of the disposition of a portion of liquid to resist a force.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000421 -->
+    <!-- validation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000421">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000421">
         <rdfs:label>validation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000064"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <dc:description>An algorithm that specifies how to determine whether data meets given criteria for correctness.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000422 -->
+    <!-- standardization algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000422">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000422">
         <rdfs:label>standardization algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000064"/>
-        <dc:description>An algorithm that specifies how to transform data such that the resulting data meets given criteria for correctness.</dc:description>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>An algorithm that specifies how to transform data such that the resulting data meets given criteria for correctness.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000423 -->
+    <!-- structural validation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000423">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000423">
         <rdfs:label>structural validation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000421"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000421"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000330"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000085"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000330"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <dc:description>A validation algorithm that specifies how to determine whether a structural descriptor meets given criteria for correctness.</dc:description>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>A validation algorithm that specifies how to determine whether a structural descriptor meets given criteria for correctness.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000424 -->
+    <!-- structural standardization algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000424">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000424">
         <rdfs:label>structural standardization algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000422"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000422"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000330"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000085"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000330"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000085"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
@@ -4498,15 +4471,15 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000425 -->
+    <!-- structural validation warning -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000425">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000425">
         <rdfs:label>structural validation warning</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000506"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000506"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000423"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000423"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
@@ -4515,34 +4488,34 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000426 -->
+    <!-- structural validation error -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000426">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000426">
         <rdfs:label>structural validation error</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000507"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000507"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000424"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000424"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <dc:description>An error message that indicates that a structural descriptor cannot be validated.</dc:description>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>An error message that indicates that a structural descriptor cannot be validated.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000427 -->
+    <!-- structural standardization -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000427">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000427">
         <rdfs:label>structural standardization</rdfs:label>
         <rdfs:subClassOf>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&ro;has_participant"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000424"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000424"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -4553,17 +4526,17 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000428 -->
+    <!-- structural validation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000428">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000428">
         <rdfs:label>structural validation</rdfs:label>
         <rdfs:subClassOf>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&ro;has_participant"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000423"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000423"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -4574,18 +4547,18 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000446 -->
+    <!-- CAS registry number -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000446">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000446">
         <rdfs:label>CAS registry number</rdfs:label>
         <dc:description>Identifier used by the Chemical Abstracts Service database.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000447 -->
+    <!-- European Community number -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000447">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000447">
         <rdfs:label>EC number</rdfs:label>
         <rdfs:label>EINECS No</rdfs:label>
         <rdfs:label>European Community number</rdfs:label>
@@ -4594,17 +4567,17 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000450 -->
+    <!-- algorithm to calculate a molecular descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000450">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000450">
         <rdfs:label>algorithm to calculate a molecular descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000144"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000144"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000065"/>
+                        <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000065"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -4613,78 +4586,87 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000505 -->
+    <!-- software message data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000505">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000505">
         <rdfs:label>software message data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
         <obo:IAO_0000115>A software message data item is a data item that plays the role of a message generated by a software implementation, for example, an error, warning or success message.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000506 -->
+    <!-- warning message -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000506">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000506">
         <rdfs:label>warning message</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000505"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000505"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000507 -->
+    <!-- error message -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000507">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000507">
         <rdfs:label>error message</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000505"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000505"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000508 -->
+    <!-- success message -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000508">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000508">
         <rdfs:label>success message</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000505"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000505"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000513 -->
+    <!-- chemical substance descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000513">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000513">
         <rdfs:label>chemical substance descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000123"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000123"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001100 -->
+    <!-- Wikidata identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001100">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000567">
+        <rdfs:label>Wikidata identifier</rdfs:label>
+        <dc:description>Database identifier used by Wikidata.</dc:description>
+    </owl:Class>
+    
+
+
+    <!-- Bond Polarizabilities -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001100">
         <rdfs:label>Bond Polarizabilities</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000086"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&obo;CHEBI_23367"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000086"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Descriptor that calculates the sum of the absolute value of the difference between atomic polarizabilities of all bonded atoms in the molecule (including implicit hydrogens).</dc:description>
@@ -4692,9 +4674,9 @@ The formal charge of any atom in a molecule can be calculated by the following e
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#Thing -->
+    <!-- Thing -->
 
-    <owl:Class rdf:about="&owl;Thing"/>
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
     
 
 
@@ -4707,16 +4689,16 @@ The formal charge of any atom in a molecule can be calculated by the following e
      -->
 
     <rdf:Description>
-        <rdf:type rdf:resource="&owl;AllDisjointClasses"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="&resource;CHEMINF_000133"/>
-            <rdf:Description rdf:about="&resource;CHEMINF_000134"/>
-            <rdf:Description rdf:about="&resource;CHEMINF_000135"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000133"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000134"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000135"/>
         </owl:members>
     </rdf:Description>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
 

--- a/ontology/cheminf-external.owl
+++ b/ontology/cheminf-external.owl
@@ -1,50 +1,23 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY bfo "http://www.ifomis.org/bfo/1.1#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY snap "http://www.ifomis.org/bfo/1.1/snap#" >
-    <!ENTITY span "http://www.ifomis.org/bfo/1.1/span#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-]>
-
-
 <rdf:RDF xmlns="http://semanticscience.org/ontology/cheminf-external.owl#"
      xml:base="http://semanticscience.org/ontology/cheminf-external.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
-     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#"
-     xmlns:resource="http://semanticscience.org/resource/"
-     xmlns:bfo="http://www.ifomis.org/bfo/1.1#"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
-     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://semanticscience.org/ontology/cheminf-external.owl">
-        <rdfs:comment rdf:datatype="&xsd;string">Document containing upporting external terms</rdfs:comment>
-        <dc:creator rdf:datatype="&xsd;string">Michel Dumontier</dc:creator>
-        <dc:title rdf:datatype="&xsd;string">Supporting terminology for chemical information ontology (cheminf)</dc:title>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
-        <protege:defaultLanguage rdf:datatype="&xsd;string">en</protege:defaultLanguage>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Document containing upporting external terms</rdfs:comment>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
+        <protege:defaultLanguage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</protege:defaultLanguage>
+        <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Michel Dumontier</dc:creator>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
         <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Supporting terminology for chemical information ontology (cheminf)</dc:title>
     </owl:Ontology>
     
 
@@ -57,39 +30,138 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:AnnotationProperty rdf:about="&protege;defaultLanguage"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000116"/>
-    <owl:AnnotationProperty rdf:about="&dc;contributor"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000114"/>
-    <owl:AnnotationProperty rdf:about="&dc;language"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000119"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000117"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000118"/>
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasAlternativeId"/>
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasOBONamespace"/>
-    <owl:AnnotationProperty rdf:about="&dc;source"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000111"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000112"/>
-    <owl:AnnotationProperty rdf:about="&dc;creator"/>
-    <owl:AnnotationProperty rdf:about="&dc;publisher"/>
-    <owl:AnnotationProperty rdf:about="&oboInOwl;savedBy"/>
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000412"/>
-    <owl:AnnotationProperty rdf:about="&dc;identifier"/>
-    <owl:AnnotationProperty rdf:about="&dc;format"/>
-    <owl:AnnotationProperty rdf:about="&dc;title"/>
-    <owl:AnnotationProperty rdf:about="&dc;rights"/>
     
 
 
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+    <!-- defaultLanguage -->
 
+    <owl:AnnotationProperty rdf:about="http://protege.stanford.edu/plugins/owl/protege#defaultLanguage"/>
+    
+
+
+    <!-- IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111"/>
+    
+
+
+    <!-- IAO_0000112 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112"/>
+    
+
+
+    <!-- IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114"/>
+    
+
+
+    <!-- IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    
+
+
+    <!-- IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
+    
+
+
+    <!-- IAO_0000117 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
+    
+
+
+    <!-- IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    
+
+
+    <!-- IAO_0000119 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119"/>
+    
+
+
+    <!-- IAO_0000412 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412"/>
+    
+
+
+    <!-- contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor"/>
+    
+
+
+    <!-- creator -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/creator"/>
+    
+
+
+    <!-- format -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/format"/>
+    
+
+
+    <!-- identifier -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/identifier"/>
+    
+
+
+    <!-- language -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/language"/>
+    
+
+
+    <!-- publisher -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/publisher"/>
+    
+
+
+    <!-- rights -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/rights"/>
+    
+
+
+    <!-- source -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
+    
+
+
+    <!-- title -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
+    
+
+
+    <!-- hasAlternativeId -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
+    
+
+
+    <!-- hasOBONamespace -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace"/>
+    
+
+
+    <!-- savedBy -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#savedBy"/>
     
 
 
@@ -104,261 +176,354 @@
     
 
 
-    <!-- http://purl.org/obo/owl/OBO_REL#bearer_of -->
+    <!-- part_of -->
 
-    <owl:ObjectProperty rdf:about="&OBO_REL;bearer_of">
-        <rdfs:range rdf:resource="&snap;DependentContinuant"/>
-        <rdfs:domain rdf:resource="&snap;IndependentContinuant"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#adjacent_to -->
-
-    <owl:ObjectProperty rdf:about="&ro;adjacent_to">
-        <rdfs:label xml:lang="en">adjacent_to</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Note that adjacent_to as thus defined is not a symmetric relation, in contrast to its instance-level counterpart. For it can be the case that Cs are in general such as to be adjacent to instances of C1 while no analogous statement holds for C1s in general in relation to instances of C. Examples are: nuclear membrane adjacent_to cytoplasm; seminal vesicle adjacent_to urinary bladder; ovary adjacent_to parietal pelvic peritoneum</rdfs:comment>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000012</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#agent_in -->
-
-    <owl:ObjectProperty rdf:about="&ro;agent_in">
-        <rdfs:label xml:lang="en">agent_in</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000022</oboInOwl:hasAlternativeId>
-        <rdfs:subPropertyOf rdf:resource="&ro;participates_in"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#contained_in -->
-
-    <owl:ObjectProperty rdf:about="&ro;contained_in">
-        <rdfs:label xml:lang="en">contained_in</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Containment obtains in each case between material and immaterial continuants, for instance: lung contained_in thoracic cavity; bladder contained_in pelvic cavity. Hence containment is not a transitive relation.    If c part_of c1 at t then we have also, by our definition and by the axioms of mereology applied to spatial regions, c located_in c1 at t. Thus, many examples of instance-level location relations for continuants are in fact cases of instance-level parthood. For material continuants location and parthood coincide. Containment is location not involving parthood, and arises only where some immaterial continuant is involved. To understand this relation, we first define overlap for continuants as follows:    c1 overlap c2 at t =def for some c, c part_of c1 at t and c part_of c2 at t. The containment relation on the instance level can then be defined (see definition):</rdfs:comment>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000010</oboInOwl:hasAlternativeId>
-        <owl:inverseOf rdf:resource="&ro;contains"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#contains -->
-
-    <owl:ObjectProperty rdf:about="&ro;contains">
-        <rdfs:label xml:lang="en">contains</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000011</oboInOwl:hasAlternativeId>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#derived_into -->
-
-    <owl:ObjectProperty rdf:about="&ro;derived_into">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">derived_into</rdfs:label>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000016</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#derives_from -->
-
-    <owl:ObjectProperty rdf:about="&ro;derives_from">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">derives_from</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Derivation as a relation between instances. The temporal relation of derivation is more complex. Transformation, on the instance level, is just the relation of identity: each adult is identical to some child existing at some earlier time. Derivation on the instance-level is a relation holding between non-identicals. More precisely, it holds between distinct material continuants when one succeeds the other across a temporal divide in such a way that at least a biologically significant portion of the matter of the earlier continuant is inherited by the later. Thus we will have axioms to the effect that from c derives_from c1 we can infer that c and c1 are not identical and that there is some instant of time t such that c1 exists only prior to and c only subsequent to t. We will also be able to infer that the spatial region occupied by c as it begins to exist at t overlaps with the spatial region occupied by c1 as it ceases to exist in the same instant.</rdfs:comment>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000015</oboInOwl:hasAlternativeId>
-        <owl:inverseOf rdf:resource="&ro;derived_into"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_agent -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_agent">
-        <rdfs:label xml:lang="en">has_agent</rdfs:label>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000021</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <owl:inverseOf rdf:resource="&ro;agent_in"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_participant"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_integral_part -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_integral_part">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">has_integral_part</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000005</oboInOwl:hasAlternativeId>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_part"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_part -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_part">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">has_part</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000003</oboInOwl:hasAlternativeId>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_participant -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_participant">
-        <rdfs:label xml:lang="en">has_participant</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time.</rdfs:comment>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000019</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <owl:inverseOf rdf:resource="&ro;participates_in"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_proper_part -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_proper_part">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">has_proper_part</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000007</oboInOwl:hasAlternativeId>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_part"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#integral_part_of -->
-
-    <owl:ObjectProperty rdf:about="&ro;integral_part_of">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">integral_part_of</rdfs:label>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000004</oboInOwl:hasAlternativeId>
-        <owl:inverseOf rdf:resource="&ro;has_integral_part"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;part_of"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#located_in -->
-
-    <owl:ObjectProperty rdf:about="&ro;located_in">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">located_in</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Location as a relation between instances: The primitive instance-level relation c located_in r at t reflects the fact that each continuant is at any given time associated with exactly one spatial region, namely its exact location. Following we can use this relation to define a further instance-level location relation - not between a continuant and the region which it exactly occupies, but rather between one continuant and another. c is located in c1, in this sense, whenever the spatial region occupied by c is part_of the spatial region occupied by c1.    Note that this relation comprehends both the relation of exact location between one continuant and another which obtains when r and r1 are identical (for example, when a portion of fluid exactly fills a cavity), as well as those sorts of inexact location relations which obtain, for example, between brain and head or between ovum and uterus</rdfs:comment>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000008</oboInOwl:hasAlternativeId>
-        <owl:inverseOf rdf:resource="&ro;location_of"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#location_of -->
-
-    <owl:ObjectProperty rdf:about="&ro;location_of">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">location_of</rdfs:label>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000009</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#part_of -->
-
-    <owl:ObjectProperty rdf:about="&ro;part_of">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label xml:lang="en">part_of</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">Parthood as a relation between instances: The primitive instance-level relation p part_of p1 is illustrated in assertions such as: this instance of rhodopsin mediated phototransduction part_of this instance of visual perception.    This relation satisfies at least the following standard axioms of mereology: reflexivity (for all p, p part_of p); anti-symmetry (for all p, p1, if p part_of p1 and p1 part_of p then p and p1 are identical); and transitivity (for all p, p1, p2, if p part_of p1 and p1 part_of p2, then p part_of p2). Analogous axioms hold also for parthood as a relation between spatial regions.    For parthood as a relation between continuants, these axioms need to be modified to take account of the incorporation of a temporal argument. Thus for example the axiom of transitivity for continuants will assert that if c part_of c1 at t and c1 part_of c2 at t, then also c part_of c2 at t.    Parthood as a relation between classes: To define part_of as a relation between classes we again need to distinguish the two cases of continuants and processes, even though the explicit reference to instants of time now falls away. For continuants, we have C part_of C1 if and only if any instance of C at any time is an instance-level part of some instance of C1 at that time, as for example in: cell nucleus part_ of cell.</rdfs:comment>
-        <obo:IAO_0000116 rdf:datatype="&xsd;string">There is controversy about this relation intended to represent the relation between some arbitrary physical thing that is used as a represention/proxy/pointer to something else</obo:IAO_0000116>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parthood as a relation between instances: The primitive instance-level relation p part_of p1 is illustrated in assertions such as: this instance of rhodopsin mediated phototransduction part_of this instance of visual perception.    This relation satisfies at least the following standard axioms of mereology: reflexivity (for all p, p part_of p); anti-symmetry (for all p, p1, if p part_of p1 and p1 part_of p then p and p1 are identical); and transitivity (for all p, p1, p2, if p part_of p1 and p1 part_of p2, then p part_of p2). Analogous axioms hold also for parthood as a relation between spatial regions.    For parthood as a relation between continuants, these axioms need to be modified to take account of the incorporation of a temporal argument. Thus for example the axiom of transitivity for continuants will assert that if c part_of c1 at t and c1 part_of c2 at t, then also c part_of c2 at t.    Parthood as a relation between classes: To define part_of as a relation between classes we again need to distinguish the two cases of continuants and processes, even though the explicit reference to instants of time now falls away. For continuants, we have C part_of C1 if and only if any instance of C at any time is an instance-level part of some instance of C1 at that time, as for example in: cell nucleus part_ of cell.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">There is controversy about this relation intended to represent the relation between some arbitrary physical thing that is used as a represention/proxy/pointer to something else</obo:IAO_0000116>
         <oboInOwl:hasAlternativeId>OBO_REL:0000002</oboInOwl:hasAlternativeId>
-        <owl:inverseOf rdf:resource="&ro;has_part"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#participates_in -->
-
-    <owl:ObjectProperty rdf:about="&ro;participates_in">
-        <rdfs:label xml:lang="en">participates_in</rdfs:label>
         <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000020</oboInOwl:hasAlternativeId>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.obofoundry.org/ro/ro.owl#preceded_by -->
+    <!-- has_part -->
 
-    <owl:ObjectProperty rdf:about="&ro;preceded_by">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">has_part</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000003</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- preceded_by -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000062">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label xml:lang="en">preceded_by</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">An example is: translation preceded_by transcription; aging preceded_by development (not however death preceded_by aging). Where derives_from links classes of continuants, preceded_by links classes of processes. Clearly, however, these two relations are not independent of each other. Thus if cells of type C1 derive_from cells of type C, then any cell division involving an instance of C1 in a given lineage is preceded_by cellular processes involving an instance of C.    The assertion P preceded_by P1 tells us something about Ps in general: that is, it tells us something about what happened earlier, given what we know about what happened later. Thus it does not provide information pointing in the opposite direction, concerning instances of P1 in general; that is, that each is such as to be succeeded by some instance of P. Note that an assertion to the effect that P preceded_by P1 is rather weak; it tells us little about the relations between the underlying instances in virtue of which the preceded_by relation obtains. Typically we will be interested in stronger relations, for example in the relation immediately_preceded_by, or in relations which combine preceded_by with a condition to the effect that the corresponding instances of P and P1 share participants, or that their participants are connected by relations of derivation, or (as a first step along the road to a treatment of causality) that the one process in some way affects (for example, initiates or regulates) the other.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An example is: translation preceded_by transcription; aging preceded_by development (not however death preceded_by aging). Where derives_from links classes of continuants, preceded_by links classes of processes. Clearly, however, these two relations are not independent of each other. Thus if cells of type C1 derive_from cells of type C, then any cell division involving an instance of C1 in a given lineage is preceded_by cellular processes involving an instance of C.    The assertion P preceded_by P1 tells us something about Ps in general: that is, it tells us something about what happened earlier, given what we know about what happened later. Thus it does not provide information pointing in the opposite direction, concerning instances of P1 in general; that is, that each is such as to be succeeded by some instance of P. Note that an assertion to the effect that P preceded_by P1 is rather weak; it tells us little about the relations between the underlying instances in virtue of which the preceded_by relation obtains. Typically we will be interested in stronger relations, for example in the relation immediately_preceded_by, or in relations which combine preceded_by with a condition to the effect that the corresponding instances of P and P1 share participants, or that their participants are connected by relations of derivation, or (as a first step along the road to a treatment of causality) that the one process in some way affects (for example, initiates or regulates) the other.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000063"/>
         <oboInOwl:hasAlternativeId>OBO_REL:0000017</oboInOwl:hasAlternativeId>
         <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <owl:inverseOf rdf:resource="&ro;precedes"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.obofoundry.org/ro/ro.owl#precedes -->
+    <!-- precedes -->
 
-    <owl:ObjectProperty rdf:about="&ro;precedes">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000063">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label xml:lang="en">precedes</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000062"/>
         <oboInOwl:hasAlternativeId>OBO_REL:0000018</oboInOwl:hasAlternativeId>
         <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.obofoundry.org/ro/ro.owl#proper_part_of -->
+    <!-- RO_0000053 -->
 
-    <owl:ObjectProperty rdf:about="&ro;proper_part_of">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">proper_part_of</rdfs:label>
-        <oboInOwl:hasAlternativeId>OBO_REL:0000006</oboInOwl:hasAlternativeId>
-        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
-        <owl:inverseOf rdf:resource="&ro;has_proper_part"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;part_of"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <rdfs:range rdf:resource="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.obofoundry.org/ro/ro.owl#transformation_of -->
+    <!-- participates_in -->
 
-    <owl:ObjectProperty rdf:about="&ro;transformation_of">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056">
+        <rdfs:label xml:lang="en">participates_in</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000020</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_participant -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
+        <rdfs:label xml:lang="en">has_participant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000019</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- derives_from -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001000">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">derives_from</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Derivation as a relation between instances. The temporal relation of derivation is more complex. Transformation, on the instance level, is just the relation of identity: each adult is identical to some child existing at some earlier time. Derivation on the instance-level is a relation holding between non-identicals. More precisely, it holds between distinct material continuants when one succeeds the other across a temporal divide in such a way that at least a biologically significant portion of the matter of the earlier continuant is inherited by the later. Thus we will have axioms to the effect that from c derives_from c1 we can infer that c and c1 are not identical and that there is some instant of time t such that c1 exists only prior to and c only subsequent to t. We will also be able to infer that the spatial region occupied by c as it begins to exist at t overlaps with the spatial region occupied by c1 as it ceases to exist in the same instant.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001001"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000015</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- derived_into -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001001">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">derived_into</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001000"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000016</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- location_of -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001015">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">location_of</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001025"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000009</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- contained_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001018">
+        <rdfs:label xml:lang="en">contained_in</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Containment obtains in each case between material and immaterial continuants, for instance: lung contained_in thoracic cavity; bladder contained_in pelvic cavity. Hence containment is not a transitive relation.    If c part_of c1 at t then we have also, by our definition and by the axioms of mereology applied to spatial regions, c located_in c1 at t. Thus, many examples of instance-level location relations for continuants are in fact cases of instance-level parthood. For material continuants location and parthood coincide. Containment is location not involving parthood, and arises only where some immaterial continuant is involved. To understand this relation, we first define overlap for continuants as follows:    c1 overlap c2 at t =def for some c, c part_of c1 at t and c part_of c2 at t. The containment relation on the instance level can then be defined (see definition):</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001019"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000010</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- contains -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001019">
+        <rdfs:label xml:lang="en">contains</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001018"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000011</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- located_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001025">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">located_in</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Location as a relation between instances: The primitive instance-level relation c located_in r at t reflects the fact that each continuant is at any given time associated with exactly one spatial region, namely its exact location. Following we can use this relation to define a further instance-level location relation - not between a continuant and the region which it exactly occupies, but rather between one continuant and another. c is located in c1, in this sense, whenever the spatial region occupied by c is part_of the spatial region occupied by c1.    Note that this relation comprehends both the relation of exact location between one continuant and another which obtains when r and r1 are identical (for example, when a portion of fluid exactly fills a cavity), as well as those sorts of inexact location relations which obtain, for example, between brain and head or between ovum and uterus</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0001015"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000008</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- agent_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002217">
+        <rdfs:label xml:lang="en">agent_in</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002218"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000022</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_agent -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002218">
+        <rdfs:label xml:lang="en">has_agent</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002217"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000021</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- adjacent_to -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002220">
+        <rdfs:label xml:lang="en">adjacent_to</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Note that adjacent_to as thus defined is not a symmetric relation, in contrast to its instance-level counterpart. For it can be the case that Cs are in general such as to be adjacent to instances of C1 while no analogous statement holds for C1s in general in relation to instances of C. Examples are: nuclear membrane adjacent_to cytoplasm; seminal vesicle adjacent_to urinary bladder; ovary adjacent_to parietal pelvic peritoneum</rdfs:comment>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000012</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- transformation_of -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002494">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label xml:lang="en">transformation_of</rdfs:label>
-        <rdfs:comment rdf:datatype="&xsd;string">When an embryonic oenocyte (a type of insect cell) is transformed into a larval oenocyte, one and the same continuant entity preserves its identity while instantiating distinct classes at distinct times. The class-level relation transformation_of obtains between continuant classes C and C1 wherever each instance of the class C is such as to have existed at some earlier time as an instance of the distinct class C1 (see Figure 2 in paper). This relation is illustrated first of all at the molecular level of granularity by the relation between mature RNA and the pre-RNA from which it is processed, or between (UV-induced) thymine-dimer and thymine dinucleotide. At coarser levels of granularity it is illustrated by the transformations involved in the creation of red blood cells, for example, from reticulocyte to erythrocyte, and by processes of development, for example, from larva to pupa, or from (post-gastrular) embryo to fetus or from child to adult. It is also manifest in pathological transformations, for example, of normal colon into carcinomatous colon. In each such case, one and the same continuant entity instantiates distinct classes at different times in virtue of phenotypic changes.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">When an embryonic oenocyte (a type of insect cell) is transformed into a larval oenocyte, one and the same continuant entity preserves its identity while instantiating distinct classes at distinct times. The class-level relation transformation_of obtains between continuant classes C and C1 wherever each instance of the class C is such as to have existed at some earlier time as an instance of the distinct class C1 (see Figure 2 in paper). This relation is illustrated first of all at the molecular level of granularity by the relation between mature RNA and the pre-RNA from which it is processed, or between (UV-induced) thymine-dimer and thymine dinucleotide. At coarser levels of granularity it is illustrated by the transformations involved in the creation of red blood cells, for example, from reticulocyte to erythrocyte, and by processes of development, for example, from larva to pupa, or from (post-gastrular) embryo to fetus or from child to adult. It is also manifest in pathological transformations, for example, of normal colon into carcinomatous colon. In each such case, one and the same continuant entity instantiates distinct classes at different times in virtue of phenotypic changes.</rdfs:comment>
         <oboInOwl:hasAlternativeId>OBO_REL:0000013</oboInOwl:hasAlternativeId>
         <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
     </owl:ObjectProperty>
     
 
 
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+    <!-- bearer_of -->
 
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000053">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    </owl:ObjectProperty>
     
+
+
+    <!-- agent_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002217">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- contained_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001018"/>
+    
+
+
+    <!-- contains -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001019"/>
+    
+
+
+    <!-- derived_into -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001001"/>
+    
+
+
+    <!-- derives_from -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001000"/>
+    
+
+
+    <!-- has_agent -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002218">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_integral_part -->
+
+    <owl:ObjectProperty rdf:about="http://www.obofoundry.org/ro/ro.owl#has_integral_part">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">has_integral_part</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+        <owl:inverseOf rdf:resource="http://www.obofoundry.org/ro/ro.owl#integral_part_of"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000005</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_part -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
+    
+
+
+    <!-- has_participant -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057"/>
+    
+
+
+    <!-- has_proper_part -->
+
+    <owl:ObjectProperty rdf:about="http://www.obofoundry.org/ro/ro.owl#has_proper_part">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">has_proper_part</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+        <owl:inverseOf rdf:resource="http://www.obofoundry.org/ro/ro.owl#proper_part_of"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000007</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- integral_part_of -->
+
+    <owl:ObjectProperty rdf:about="http://www.obofoundry.org/ro/ro.owl#integral_part_of">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">integral_part_of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000004</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- located_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001025"/>
+    
+
+
+    <!-- location_of -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0001015"/>
+    
+
+
+    <!-- part_of -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+    
+
+
+    <!-- participates_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000056"/>
+    
+
+
+    <!-- preceded_by -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000062"/>
+    
+
+
+    <!-- precedes -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000063"/>
+    
+
+
+    <!-- proper_part_of -->
+
+    <owl:ObjectProperty rdf:about="http://www.obofoundry.org/ro/ro.owl#proper_part_of">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">proper_part_of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+        <oboInOwl:hasAlternativeId>OBO_REL:0000006</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>relationship</oboInOwl:hasOBONamespace>
+    </owl:ObjectProperty>
+    
+
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -366,95 +531,20 @@
     // Classes
     //
     ///////////////////////////////////////////////////////////////////////////////////////
-  -->   
+     -->
 
- <!-- http://purl.obolibrary.org/obo/OBI_0000011 -->
-
-    <owl:Class rdf:about="&obo;OBI_0000011">
-        <rdfs:label xml:lang="en">planned process</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;Process"/>
-        <obo:IAO_0000412 rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
-        <obo:IAO_0000115 xml:lang="en">A planned process is the realization of a plan  borne by an agent that initiates this process in order to bring about the objective(s) specified as part of the plan specification.</obo:IAO_0000115>
-        <obo:IAO_0000111 xml:lang="en">planned process</obo:IAO_0000111>
-    </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0000066 -->
+    <!-- entity -->
 
-    <owl:Class rdf:about="&obo;OBI_0000066">
-        <rdfs:label xml:lang="en">investigation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;OBI_0000011"/>
-        <obo:IAO_0000412 rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
-        <obo:IAO_0000115 xml:lang="en">An investigation is a process with the objective to generate an 
-information entity by planning protocol applications included in an overall study design, carrying them out and documenting  the results. In addition, an investigation can include a sub process of interpreting the data to draw conclusions.</obo:IAO_0000115>
-        <obo:IAO_0000111 xml:lang="en">investigation</obo:IAO_0000111>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000471 -->
-
-    <owl:Class rdf:about="&obo;OBI_0000471">
-        <rdfs:label rdf:datatype="&xsd;string">study design execution</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;OBI_0000011"/>
-        <obo:IAO_0000115 rdf:datatype="&xsd;string">a planned process that realizes the concretization of a study design</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
-        <obo:IAO_0000111 rdf:datatype="&xsd;string">study design execution</obo:IAO_0000111>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000566 -->
-
-    <owl:Class rdf:about="&obo;OBI_0000566">
-        <rdfs:label>NMR instrument</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;OBI_0400002"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0400002 -->
-
-    <owl:Class rdf:about="&obo;OBI_0400002">
-        <rdfs:label>device</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;MaterialEntity"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0500000 -->
-
-    <owl:Class rdf:about="&obo;OBI_0500000">
-        <rdfs:label xml:lang="en">study design</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000104"/>
-        <obo:IAO_0000115 rdf:datatype="&xsd;string">A study design is a plan comprising of protocols and/or data transformations that are executed as part of an investigation. The objective of the study design is to produce results (information). The study design specifies how the different data produced in the execution of the investigation are related, how they are interpreted, and what are the desired results.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:datatype="&xsd;anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
-        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.org/obo/owl/UO#UO_0000001 -->
-
-    <owl:Class rdf:about="&obo;UO_0000001">
-        <rdfs:label>length unit</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000003"/>
-        <obo:IAO_0000412 rdf:datatype="&xsd;anyURI">http://purl.org/obo/owl/UO</obo:IAO_0000412>
-        <obo:IAO_0000111 rdf:datatype="&xsd;string">length unit label</obo:IAO_0000111>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1#Entity -->
-
-    <owl:Class rdf:about="&bfo;Entity">
-        <rdfs:label rdf:datatype="&xsd;string">entity</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">entity</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;Continuant"/>
-                    <rdf:Description rdf:about="&span;Occurrent"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
@@ -462,608 +552,1158 @@ information entity by planning protocol applications included in an overall stud
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Continuant -->
+    <!-- continuant -->
 
-    <owl:Class rdf:about="&snap;Continuant">
-        <rdfs:label rdf:datatype="&xsd;string">continuant</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">continuant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An entity [bfo:Entity] that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a heart, a person, the color of a tomato, the mass of a cloud, a symphony orchestra, the disposition of blood to coagulate, the lawn and atmosphere in front of our building</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: endurant</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;DependentContinuant"/>
-                    <rdf:Description rdf:about="&snap;IndependentContinuant"/>
-                    <rdf:Description rdf:about="&snap;SpatialRegion"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000006"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&bfo;Entity"/>
-        <owl:disjointWith rdf:resource="&span;Occurrent"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An entity [bfo:Entity] that exists in full at any time in which it exists at all, persists through time while maintaining its identity and has no temporal parts.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a heart, a person, the color of a tomato, the mass of a cloud, a symphony orchestra, the disposition of blood to coagulate, the lawn and atmosphere in front of our building</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: endurant</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#DependentContinuant -->
+    <!-- occurrent -->
 
-    <owl:Class rdf:about="&snap;DependentContinuant">
-        <rdfs:label rdf:datatype="&xsd;string">dependent_continuant</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">occurrent</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An entity [bfo:Entity] that has temporal parts and that happens, unfolds or develops through time. Sometimes also called perdurants.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the life of an organism, a surgical operation as processual context for a nosocomical infection, the spatiotemporal context occupied by a process of cellular meiosis, the most interesting part of Van Gogh&apos;s life, the spatiotemporal region occupied by the development of a cancer tumor</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: perdurant</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;GenericallyDependentContinuant"/>
-                    <rdf:Description rdf:about="&snap;SpecificallyDependentContinuant"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000011"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000008"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&snap;Continuant"/>
-        <owl:disjointWith rdf:resource="&snap;IndependentContinuant"/>
-        <owl:disjointWith rdf:resource="&snap;SpatialRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A continuant [snap:Continuant] that is either dependent on one or other independent continuant [snap:IndependentContinuant] bearers or inheres in or is borne by other entities.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Disposition -->
+    <!-- independent_continuant -->
 
-    <owl:Class rdf:about="&snap;Disposition">
-        <rdfs:label rdf:datatype="&xsd;string">disposition</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;RealizableEntity"/>
-        <owl:disjointWith rdf:resource="&snap;Function"/>
-        <owl:disjointWith rdf:resource="&snap;Role"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A realizable entity [snap:RealizableEntity] that essentially causes a specific process or transformation in the object [snap:Object] in which it inheres, under specific circumstances and in conjunction with the laws of nature. A general formula for dispositions is: X (object [snap:Object] has the disposition D to (transform, initiate a process) R under conditions C.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the disposition of vegetables to decay when not refrigerated, the disposition of a vase to brake if dropped, the disposition of blood to coagulate, the disposition of a patient with a weakened immune system to contract disease, the disposition of metal to conduct electricity.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#FiatObjectPart -->
-
-    <owl:Class rdf:about="&snap;FiatObjectPart">
-        <rdfs:label rdf:datatype="&xsd;string">fiat_object_part</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;MaterialEntity"/>
-        <owl:disjointWith rdf:resource="&snap;Object"/>
-        <owl:disjointWith rdf:resource="&snap;ObjectAggregate"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A material entity [snap:MaterialEntity] that is part of an object [snap:Object] but is not demarcated by any physical discontinuities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: upper and lower lobes of the left lung, the dorsal and ventral surfaces of the body, the east side of Saarbruecken, the lower right portion of a human torso</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: fiat substance part</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Function -->
-
-    <owl:Class rdf:about="&snap;Function">
-        <rdfs:label rdf:datatype="&xsd;string">function</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;RealizableEntity"/>
-        <owl:disjointWith rdf:resource="&snap;Role"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A realizable entity [snap:RealizableEntity] the manifestation of which is an essentially end-directed activity of a continuant [snap:Continuant] entity in virtue of that continuant [snap:Continuant] entity being a specific kind of entity in the kind or kinds of contexts that it is made for.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the function of a birth canal to enable transport, the function of the heart in the body: to pump blood, to receive de-oxygenated and oxygenated blood, etc., the function of reproduction in the transmission of genetic material, the digestive function of the stomach to nutriate the body, the function of a hammer to drive in nails, the function of a computer program to compute mathematical equations, the function of an automobile to provide transportation, the function of a judge in a court of law</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#GenericallyDependentContinuant -->
-
-    <owl:Class rdf:about="&snap;GenericallyDependentContinuant">
-        <rdfs:label rdf:datatype="&xsd;string">generically_dependent_continuant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;DependentContinuant"/>
-        <owl:disjointWith rdf:resource="&snap;SpecificallyDependentContinuant"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A continuant [snap:Continuant] that is dependent on one or other independent continuant [snap:IndependentContinuant] bearers. For every instance of A requires some instance of (an independent continuant [snap:IndependentContinuant] type) B but which instance of B serves can change from time to time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a certain PDF file that exists in different and in several hard drives</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#IndependentContinuant -->
-
-    <owl:Class rdf:about="&snap;IndependentContinuant">
-        <rdfs:label rdf:datatype="&xsd;string">independent_continuant</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000004">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">independent_continuant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A continuant [snap:Continuant] that is a bearer of quality [snap:Quality] and realizable entity [snap:RealizableEntity] entities, in which other entities inhere and which itself cannot inhere in anything.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: an organism, a heart, a leg, a person, a symphony orchestra, a chair, the bottom right portion of a human torso, the lawn and atmosphere in front of our building</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: substantial entity</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;MaterialEntity"/>
-                    <rdf:Description rdf:about="&snap;ObjectBoundary"/>
-                    <rdf:Description rdf:about="&snap;Site"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000140"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&snap;Continuant"/>
-        <owl:disjointWith rdf:resource="&snap;SpatialRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A continuant [snap:Continuant] that is a bearer of quality [snap:Quality] and realizable entity [snap:RealizableEntity] entities, in which other entities inhere and which itself cannot inhere in anything.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: an organism, a heart, a leg, a person, a symphony orchestra, a chair, the bottom right portion of a human torso, the lawn and atmosphere in front of our building</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: substantial entity</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#MaterialEntity -->
+    <!-- spatial_region -->
 
-    <owl:Class rdf:about="&snap;MaterialEntity">
-        <rdfs:label rdf:datatype="&xsd;string">material_entity</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000006">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: All instances of continuant [snap:Continuant] are spatial entities, that is, they enter in the relation of (spatial) location with spatial region [snap:SpatialRegion] entities. As a particular case, the exact spatial location of a spatial region [snap:SpatialRegion] is this region itself.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: An instance of spatial region [snap:SpatialRegion] is a part of space. All parts of space are spatial region [snap:SpatialRegion] entities and only spatial region [snap:SpatialRegion] entities are parts of space. Space is the entire extent of the spatial universe, a designated individual, which is thus itself a spatial region [snap:SpatialRegion].</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: Space and spatial region [snap:SpatialRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of space is sometimes called &quot;absolutist&quot; or &quot;the container view&quot;. In BFO, the class site [snap:Site] allows for a so-called relational view of space, that is to say, a view according to which spatiality is a matter of relative location between entities and not a matter of being tied to space. The bridge between these two views is secured through the fact that while instances of site [snap:Site] are not spatial region [snap:SpatialRegion] entities, they are nevertheless spatial entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A continuant [snap:Continuant] that is neither bearer of quality [snap:Quality] entities nor inheres in any other entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the sum total of all space in the universe, parts of the sum total of all space in the universe</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;FiatObjectPart"/>
-                    <rdf:Description rdf:about="&snap;Object"/>
-                    <rdf:Description rdf:about="&snap;ObjectAggregate"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000026"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000028"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000018"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&snap;IndependentContinuant"/>
-        <owl:disjointWith rdf:resource="&snap;ObjectBoundary"/>
-        <owl:disjointWith rdf:resource="&snap;Site"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An independent continuant [snap:IndependentContinuant] that is spatially extended whose identity is independent of that of other entities and can be maintained through time. Note: Material entity [snap:MaterialEntity] subsumes object [snap:Object], fiat object part [snap:FiatObjectPart], and object aggregate [snap:ObjectAggregate], which assume a three level theory of granularity, which is inadequate for some domains, such as biology.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: collection of random bacteria, a chair, dorsal surface of the body</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Object -->
+    <!-- temporal_region -->
 
-    <owl:Class rdf:about="&snap;Object">
-        <rdfs:label rdf:datatype="&xsd;string">object</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;MaterialEntity"/>
-        <owl:disjointWith rdf:resource="&snap;ObjectAggregate"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A material entity [snap:MaterialEntity] that is spatially extended, maximally self-connected and self-contained (the parts of a substance are not separated from each other by spatial gaps) and possesses an internal unity. The identity of substantial object [snap:Object] entities is independent of that of other entities and can be maintained through time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: an organism, a heart, a chair, a lung, an apple</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: substance</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000008">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: All instances of occurrent [span:Occurrent] are temporal entities, that is, they enter in the relation of (temporal) location with temporal region [span:TemporalRegion] entities. As a particular case, the exact spatiotemporal location of a temporal region [span:TemporalRegion] is this region itself. Continuant [snap:Continuant] entities are not temporal entities in the technical sense just explained; they are related to time in a different way, not through temporal location but through a relation of existence at a time or during a period of time (see continuant [snap:Continuant].</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: An instance of temporal region [span:TemporalRegion] is a part of time. All parts of time are temporal region [span:TemporalRegion] entities and only temporal region [span:TemporalRegion] entities are parts of time. Time is the entire extent of the temporal universe, a designated individual, which is thus a temporal region itself.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: Time and temporal region [span:TemporalRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of time can be called &quot;absolutist&quot; or &quot;the container view&quot; in analogy to what is traditionally the case with space (see spatial region [snap:SpatialRegion].</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An occurrent [span:Occurrent] that is part of time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the time it takes to run a marathon, the duration of a surgical procedure, the moment of death</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000038"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000148"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000011"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#ObjectAggregate -->
+    <!-- two_dimensional_region -->
 
-    <owl:Class rdf:about="&snap;ObjectAggregate">
-        <rdfs:label rdf:datatype="&xsd;string">object_aggregate</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;MaterialEntity"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A material entity [snap:MaterialEntity] that is a mereological sum of separate object [snap:Object] entities and possesses non-connected boundaries.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a heap of stones, a group of commuters on the subway, a collection of random bacteria, a flock of geese, the patients in a hospital</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: substance aggregate</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000009">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">two_dimensional_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatial region [snap:SpatialRegion] with two dimensions.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the surface of a cube-shaped part of space, the surface of a sphere-shaped part of space, the surface of a rectilinear planar figure-shaped part of space</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000026"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000028"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000018"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#ObjectBoundary -->
+    <!-- spatiotemporal_region -->
 
-    <owl:Class rdf:about="&snap;ObjectBoundary">
-        <rdfs:label rdf:datatype="&xsd;string">object_boundary</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;IndependentContinuant"/>
-        <owl:disjointWith rdf:resource="&snap;Site"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: Boundaries are theoretically difficult entities to account for, however the intuitive notion of a physical boundary as a surface of some sort (whether inside or outside of a thing) will generally serve as a good guide for the use of this universal.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An independent continuant [snap:IndependentContinuant] that is a lower dimensional part of a spatial entity, normally a closed two-dimensional surface. Boundaries are those privileged parts of object [snap:Object] entities that exist at exactly the point where the object [snap:Object] is separated off from the rest of the existing entities in the world.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the surface of the skin, the surface of the earth, the surface of the interior of the stomach, the outer surface of a cell or cell wall</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: substance boundary</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000011">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatiotemporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: All instances of occurrent [span:Occurrent] are spatiotemporal entities, that is, they enter in the relation of (spatiotemporal) location with spatiotemporal region [span:SpatiotemporalRegion] entities. As a particular case, the exact spatiotemporal location of a spatiotemporal region [span:SpatiotemporalRegion] is this region itself.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: An instance of the spatiotemporal region [span:SpatiotemporalRegion] is a part of spacetime. All parts of spacetime are spatiotemporal region [span:SpatiotemporalRegion] entities and only spatiotemporal region [span:SpatiotemporalRegion] entities are parts of spacetime. In particular, neither spatial region [snap:SpatialRegion] entities nor temporal region [span:TemporalRegion] entities are in BFO parts of spacetime. Spacetime is the entire extent of the spatiotemporal universe, a designated individual, which is thus itself a spatiotemporal region [span:SpatiotemporalRegion]. Spacetime is among occurrents the analogous of space among continuant [snap:Continuant] entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: Spacetime and spatiotemporal region [span:SpatiotemporalRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of spacetime can be called &quot;absolutist&quot; or &quot;the container view&quot;. In BFO, the class processual context [span:ProcessualContext] allows for a so-called relational view of spacetime, that is to say, a view according to which spatiotemporality is a matter of relative location between entities and not a matter of being tied to spacetime. In BFO, the bridge between these two views is secured through the fact that instances of processual context [span:ProcessualContext] are too spatiotemporal entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An occurrent [span:Occurrent] at or in which processual entity [span:ProcessualEntity] entities can be located.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the spatiotemporal region occupied by a human life, the spatiotemporal region occupied by the development of a cancer tumor, the spatiotemporal context occupied by a process of cellular meiosis</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ConnectedSpatiotemporalRegion"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ScatteredSpatiotemporalRegion"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#OneDimensionalRegion -->
+    <!-- processual_entity -->
 
-    <owl:Class rdf:about="&snap;OneDimensionalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">one_dimensional_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpatialRegion"/>
-        <owl:disjointWith rdf:resource="&snap;ThreeDimensionalRegion"/>
-        <owl:disjointWith rdf:resource="&snap;TwoDimensionalRegion"/>
-        <owl:disjointWith rdf:resource="&snap;ZeroDimensionalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatial region [snap:SpatialRegion] with one dimension.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the part of space that is a line stretching from one end of absolute space to the other, an edge of a cube-shaped part of space</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">processual_entity</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An occurrent [span:Occurrent] that exists in time by occurring or happening, has temporal parts and always involves and depends on some entity.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the life of an organism, the process of meiosis, the course of a disease, the flight of a bird</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#FiatProcessPart"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#Process"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000035"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000011"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Quality -->
+    <!-- disposition -->
 
-    <owl:Class rdf:about="&snap;Quality">
-        <rdfs:label rdf:datatype="&xsd;string">quality</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpecificallyDependentContinuant"/>
-        <owl:disjointWith rdf:resource="&snap;RealizableEntity"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A specifically dependent continuant [snap:SpecificallyDependentContinuant] that is exhibited if it inheres in an entity or entities at all (a categorical property).</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the color of a tomato, the ambient temperature of air, the circumference of a waist, the shape of a nose, the mass of a piece of gold, the weight of a chimpanzee</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disposition</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A realizable entity [snap:RealizableEntity] that essentially causes a specific process or transformation in the object [snap:Object] in which it inheres, under specific circumstances and in conjunction with the laws of nature. A general formula for dispositions is: X (object [snap:Object] has the disposition D to (transform, initiate a process) R under conditions C.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the disposition of vegetables to decay when not refrigerated, the disposition of a vase to brake if dropped, the disposition of blood to coagulate, the disposition of a patient with a weakened immune system to contract disease, the disposition of metal to conduct electricity.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#RealizableEntity -->
+    <!-- realizable_entity -->
 
-    <owl:Class rdf:about="&snap;RealizableEntity">
-        <rdfs:label rdf:datatype="&xsd;string">realizable_entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpecificallyDependentContinuant"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: If a realizable entity [snap:RealizableEntity] inheres in a continuant [snap:Continuant], this does not imply that it is actually realized.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A specifically dependent continuant [snap:SpecificallyDependentContinuant] that inheres in continuant [snap:Continuant] entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the role of being a doctor, the function of the reproductive organs, the disposition of blood to coagulate, the disposition of metal to conduct electricity</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">realizable_entity</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: If a realizable entity [snap:RealizableEntity] inheres in a continuant [snap:Continuant], this does not imply that it is actually realized.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A specifically dependent continuant [snap:SpecificallyDependentContinuant] that inheres in continuant [snap:Continuant] entities and are not exhibited in full at every time in which it inheres in an entity or group of entities. The exhibition or actualization of a realizable entity is a particular manifestation, functioning or process that occurs under certain circumstances.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the role of being a doctor, the function of the reproductive organs, the disposition of blood to coagulate, the disposition of metal to conduct electricity</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Role -->
+    <!-- zero_dimensional_region -->
 
-    <owl:Class rdf:about="&snap;Role">
-        <rdfs:label rdf:datatype="&xsd;string">role</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;RealizableEntity"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A realizable entity [snap:RealizableEntity] the manifestation of which brings about some result or end that is not essential to a continuant [snap:Continuant] in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant [snap:Continuant] in some kinds of natural, social or institutional contexts.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the role of a person as a surgeon, the role of a chemical compound in an experiment, the role of a patient relative as defined by a hospital administrative form, the role of a woman as a legal mother in the context of system of laws, the role of a biological grandfather as legal guardian in the context of a system of laws, the role of ingested matter in digestion, the role of a student in a university</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000018">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zero_dimensional_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatial region [snap:SpatialRegion] with no dimensions.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a point</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000026"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000028"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000009"/>
     </owl:Class>
     
+
+
+    <!-- quality -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">quality</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A specifically dependent continuant [snap:SpecificallyDependentContinuant] that is exhibited if it inheres in an entity or entities at all (a categorical property).</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the color of a tomato, the ambient temperature of air, the circumference of a waist, the shape of a nose, the mass of a piece of gold, the weight of a chimpanzee</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+    </owl:Class>
+    
+
+
+    <!-- specifically_dependent_continuant -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000020">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">specifically_dependent_continuant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A continuant [snap:Continuant] that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the mass of a cloud, the smell of mozzarella, the liquidity of blood, the color of a tomato, the disposition of fish to decay, the role of being a doctor, the function of the heart in the body: to pump blood, to receive de-oxygenated and oxygenated blood, etc.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: property, trope, mode</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000017"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000031"/>
+    </owl:Class>
+    
+
+
+    <!-- role -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">role</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A realizable entity [snap:RealizableEntity] the manifestation of which brings about some result or end that is not essential to a continuant [snap:Continuant] in virtue of the kind of thing that it is but that can be served or participated in by that kind of continuant [snap:Continuant] in some kinds of natural, social or institutional contexts.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the role of a person as a surgeon, the role of a chemical compound in an experiment, the role of a patient relative as defined by a hospital administrative form, the role of a woman as a legal mother in the context of system of laws, the role of a biological grandfather as legal guardian in the context of a system of laws, the role of ingested matter in digestion, the role of a student in a university</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000034"/>
+    </owl:Class>
+    
+
+
+    <!-- fiat_object_part -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000024">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fiat_object_part</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A material entity [snap:MaterialEntity] that is part of an object [snap:Object] but is not demarcated by any physical discontinuities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: upper and lower lobes of the left lung, the dorsal and ventral surfaces of the body, the east side of Saarbruecken, the lower right portion of a human torso</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: fiat substance part</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000030"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000027"/>
+    </owl:Class>
+    
+
+
+    <!-- one_dimensional_region -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000026">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">one_dimensional_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatial region [snap:SpatialRegion] with one dimension.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the part of space that is a line stretching from one end of absolute space to the other, an edge of a cube-shaped part of space</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000028"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000009"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000018"/>
+    </owl:Class>
+    
+
+
+    <!-- object_aggregate -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000027">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">object_aggregate</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A material entity [snap:MaterialEntity] that is a mereological sum of separate object [snap:Object] entities and possesses non-connected boundaries.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a heap of stones, a group of commuters on the subway, a collection of random bacteria, a flock of geese, the patients in a hospital</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: substance aggregate</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000024"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000030"/>
+    </owl:Class>
+    
+
+
+    <!-- three_dimensional_region -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000028">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">three_dimensional_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatial region [snap:SpatialRegion] with three dimensions.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a cube-shaped part of space, a sphere-shaped part of space</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000026"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000009"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000018"/>
+    </owl:Class>
+    
+
+
+    <!-- site -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">site</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: An instance of Site [snap:Site] is a mixture of independent continuant [snap:IndependentContinuant] entities which act as surrounding environments for other independent continuant [snap:IndependentContinuant] entities, most importantly for instances of object [snap:Object]. A site [snap:Site] is typically made of object [snap:Object] or fiat object part [snap:FiatObjectPart] entities and a surrounding medium in which is found an object [snap:Object] occupying the site [snap:Site]. Independent continuant [snap:IndependentContinuant] entities may be associated with others (which, then, are site [snap:Site] entities) through a relation of &quot;occupation&quot;. That relation is connected to, but distinct from, the relation of spatial location. Site [snap:Site] entities are not to be confused with spatial region [snap:SpatialRegion] entities. In BFO, site [snap:Site] allows for a so-called relational view of space which is different from the view corresponding to the class spatial region [snap:SpatialRegion] (see the comment on this class).</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An independent continuant [snap:IndependentContinuant] consisting of a characteristic spatial shape in relation to some arrangement of other continuant [snap:Continuant] entities and of the medium which is enclosed in whole or in part by this characteristic spatial shape. Site [snap:Site] entities are entities that can be occupied by other continuant [snap:Continuant] entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a particular room in a particular hospital, Maria&apos;s nostril or her intestines for a variety of bacteria.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000140"/>
+    </owl:Class>
+    
+
+
+    <!-- object -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000030">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">object</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A material entity [snap:MaterialEntity] that is spatially extended, maximally self-connected and self-contained (the parts of a substance are not separated from each other by spatial gaps) and possesses an internal unity. The identity of substantial object [snap:Object] entities is independent of that of other entities and can be maintained through time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: an organism, a heart, a chair, a lung, an apple</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: substance</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000024"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000027"/>
+    </owl:Class>
+    
+
+
+    <!-- generically_dependent_continuant -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generically_dependent_continuant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A continuant [snap:Continuant] that is dependent on one or other independent continuant [snap:IndependentContinuant] bearers. For every instance of A requires some instance of (an independent continuant [snap:IndependentContinuant] type) B but which instance of B serves can change from time to time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: a certain PDF file that exists in different and in several hard drives</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+    </owl:Class>
+    
+
+
+    <!-- function -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000034">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">function</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A realizable entity [snap:RealizableEntity] the manifestation of which is an essentially end-directed activity of a continuant [snap:Continuant] entity in virtue of that continuant [snap:Continuant] entity being a specific kind of entity in the kind or kinds of contexts that it is made for.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the function of a birth canal to enable transport, the function of the heart in the body: to pump blood, to receive de-oxygenated and oxygenated blood, etc., the function of reproduction in the transmission of genetic material, the digestive function of the stomach to nutriate the body, the function of a hammer to drive in nails, the function of a computer program to compute mathematical equations, the function of an automobile to provide transportation, the function of a judge in a court of law</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
+    </owl:Class>
+    
+
+
+    <!-- process_boundary -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000035">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process_boundary</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A processual entity [span:ProcessualEntity] that is the fiat or bona fide instantaneous temporal process boundary.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: birth, death, the forming of a synapse, the onset of REM sleep, the detaching of a finger in an industrial accident, the final separation of two cells at the end of cell-division, the incision at the beginning of a surgery</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#FiatProcessPart"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+    </owl:Class>
+    
+
+
+    <!-- connected_temporal_region -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000038">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connected_temporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A temporal region [span:TemporalRegion] every point of which is mediately or immediately connected with every other point of which.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the 1970s years, the time from the beginning to the end of a heart attack, the time taken up by cellular meiosis</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#TemporalInstant"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#TemporalInterval"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000148"/>
+    </owl:Class>
+    
+
+
+    <!-- material_entity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material_entity</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An independent continuant [snap:IndependentContinuant] that is spatially extended whose identity is independent of that of other entities and can be maintained through time. Note: Material entity [snap:MaterialEntity] subsumes object [snap:Object], fiat object part [snap:FiatObjectPart], and object aggregate [snap:ObjectAggregate], which assume a three level theory of granularity, which is inadequate for some domains, such as biology.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: collection of random bacteria, a chair, dorsal surface of the body</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000024"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000030"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000027"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000140"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000029"/>
+    </owl:Class>
+    
+
+
+    <!-- object_boundary -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000140">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">object_boundary</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: Boundaries are theoretically difficult entities to account for, however the intuitive notion of a physical boundary as a surface of some sort (whether inside or outside of a thing) will generally serve as a good guide for the use of this universal.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An independent continuant [snap:IndependentContinuant] that is a lower dimensional part of a spatial entity, normally a closed two-dimensional surface. Boundaries are those privileged parts of object [snap:Object] entities that exist at exactly the point where the object [snap:Object] is separated off from the rest of the existing entities in the world.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the surface of the skin, the surface of the earth, the surface of the interior of the stomach, the outer surface of a cell or cell wall</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synonyms: substance boundary</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000029"/>
+    </owl:Class>
+    
+
+
+    <!-- scattered_temporal_region -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000148">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scattered_temporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A temporal region [span:TemporalRegion] every point of which is not mediately or immediately connected with every other point of which.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the time occupied by the individual games of the World Cup, the time occupied by the individual liaisons in a romantic affair</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/BFO_0000038"/>
+    </owl:Class>
+    
+
+
+    <!-- CHEBI_23367 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+    
+
+
     <!-- protein binding -->
 
-    <owl:Class rdf:about="&obo;GO_0005515">
-         <rdfs:label rdf:datatype="&xsd;string">protein binding</rdfs:label>
-         <rdfs:subClassOf rdf:resource="&span;Process"/>
-         <rdfs:comment rdf:datatype="&xsd;string">Definition: Interacting selectively and non-covalently with any protein or protein complex (a complex of two or more proteins that may include other nonprotein molecules).</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0005515">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein binding</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: Interacting selectively and non-covalently with any protein or protein complex (a complex of two or more proteins that may include other nonprotein molecules).</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
     </owl:Class>
+    
+
+
+    <!-- IAO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000003"/>
+    
+
+
+    <!-- IAO_0000104 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104"/>
+    
+
+
+    <!-- planned process -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011">
+        <rdfs:label xml:lang="en">planned process</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
+        <obo:IAO_0000111 xml:lang="en">planned process</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A planned process is the realization of a plan  borne by an agent that initiates this process in order to bring about the objective(s) specified as part of the plan specification.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
+    </owl:Class>
+    
+
+
+    <!-- investigation -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000066">
+        <rdfs:label xml:lang="en">investigation</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
+        <obo:IAO_0000111 xml:lang="en">investigation</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">An investigation is a process with the objective to generate an 
+information entity by planning protocol applications included in an overall study design, carrying them out and documenting  the results. In addition, an investigation can include a sub process of interpreting the data to draw conclusions.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
+    </owl:Class>
+    
+
+
+    <!-- study design execution -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000471">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">study design execution</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">study design execution</obo:IAO_0000111>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a planned process that realizes the concretization of a study design</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
+    </owl:Class>
+    
+
+
+    <!-- NMR instrument -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000566">
+        <rdfs:label>NMR instrument</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0400002"/>
+    </owl:Class>
+    
+
+
+    <!-- device -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0400002">
+        <rdfs:label>device</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    </owl:Class>
+    
+
+
+    <!-- study design -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
+        <rdfs:label xml:lang="en">study design</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <obo:IAO_0000111 xml:lang="en">study design</obo:IAO_0000111>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A study design is a plan comprising of protocols and/or data transformations that are executed as part of an investigation. The objective of the study design is to produce results (information). The study design specifies how the different data produced in the execution of the investigation are related, how they are interpreted, and what are the desired results.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.obolibrary.org/obo/obi.owl</obo:IAO_0000412>
+    </owl:Class>
+    
+
 
     <!-- protein -->
 
-    <owl:Class rdf:about="&obo;PR_000000001">
-         <rdfs:label rdf:datatype="&xsd;string">protein</rdfs:label>
-         <rdfs:subClassOf rdf:resource="&obo;CHEBI_23367"/>
-         <rdfs:comment rdf:datatype="&xsd;string">Definition: An amino acid chain that is produced de novo by ribosome-mediated translation of a genetically-encoded mRNA.</rdfs:comment>
-    </owl:Class>
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Site -->
-
-    <owl:Class rdf:about="&snap;Site">
-        <rdfs:label rdf:datatype="&xsd;string">site</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;IndependentContinuant"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: An instance of Site [snap:Site] is a mixture of independent continuant [snap:IndependentContinuant] entities which act as surrounding environments for other independent continuant [snap:IndependentContinuant] entities, most importantly for instances of object [snap:Object]. A site [snap:Site] is typically made of object [snap:Object] or fiat object part [snap:FiatObjectPart] entities and a surrounding medium in which is found an object [snap:Object] occupying the site [snap:Site]. Independent continuant [snap:IndependentContinuant] entities may be associated with others (which, then, are site [snap:Site] entities) through a relation of &quot;occupation&quot;. That relation is connected to, but distinct from, the relation of spatial location. Site [snap:Site] entities are not to be confused with spatial region [snap:SpatialRegion] entities. In BFO, site [snap:Site] allows for a so-called relational view of space which is different from the view corresponding to the class spatial region [snap:SpatialRegion] (see the comment on this class).</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An independent continuant [snap:IndependentContinuant] consisting of a characteristic spatial shape in relation to some arrangement of other continuant [snap:Continuant] entities and of the medium which is enclosed in whole or in part by this characteristic spatial shape. Site [snap:Site] entities are entities that can be occupied by other continuant [snap:Continuant] entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a particular room in a particular hospital, Maria&#39;s nostril or her intestines for a variety of bacteria.</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An amino acid chain that is produced de novo by ribosome-mediated translation of a genetically-encoded mRNA.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#SpatialRegion -->
+    <!-- length unit -->
 
-    <owl:Class rdf:about="&snap;SpatialRegion">
-        <rdfs:label rdf:datatype="&xsd;string">spatial_region</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UO_0000001">
+        <rdfs:label>length unit</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000003"/>
+        <obo:IAO_0000111 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">length unit label</obo:IAO_0000111>
+        <obo:IAO_0000412 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.org/obo/owl/UO</obo:IAO_0000412>
+    </owl:Class>
+    
+
+
+    <!-- Entity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000001">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;OneDimensionalRegion"/>
-                    <rdf:Description rdf:about="&snap;ThreeDimensionalRegion"/>
-                    <rdf:Description rdf:about="&snap;TwoDimensionalRegion"/>
-                    <rdf:Description rdf:about="&snap;ZeroDimensionalRegion"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&snap;Continuant"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: All instances of continuant [snap:Continuant] are spatial entities, that is, they enter in the relation of (spatial) location with spatial region [snap:SpatialRegion] entities. As a particular case, the exact spatial location of a spatial region [snap:SpatialRegion] is this region itself.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: An instance of spatial region [snap:SpatialRegion] is a part of space. All parts of space are spatial region [snap:SpatialRegion] entities and only spatial region [snap:SpatialRegion] entities are parts of space. Space is the entire extent of the spatial universe, a designated individual, which is thus itself a spatial region [snap:SpatialRegion].</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: Space and spatial region [snap:SpatialRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of space is sometimes called &quot;absolutist&quot; or &quot;the container view&quot;. In BFO, the class site [snap:Site] allows for a so-called relational view of space, that is to say, a view according to which spatiality is a matter of relative location between entities and not a matter of being tied to space. The bridge between these two views is secured through the fact that while instances of site [snap:Site] are not spatial region [snap:SpatialRegion] entities, they are nevertheless spatial entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A continuant [snap:Continuant] that is neither bearer of quality [snap:Quality] entities nor inheres in any other entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the sum total of all space in the universe, parts of the sum total of all space in the universe</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#SpecificallyDependentContinuant -->
-
-    <owl:Class rdf:about="&snap;SpecificallyDependentContinuant">
-        <rdfs:label rdf:datatype="&xsd;string">specifically_dependent_continuant</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&snap;Quality"/>
-                    <rdf:Description rdf:about="&snap;RealizableEntity"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000003"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000002"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&snap;DependentContinuant"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A continuant [snap:Continuant] that inheres in or is borne by other entities. Every instance of A requires some specific instance of B which must always be the same.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the mass of a cloud, the smell of mozzarella, the liquidity of blood, the color of a tomato, the disposition of fish to decay, the role of being a doctor, the function of the heart in the body: to pump blood, to receive de-oxygenated and oxygenated blood, etc.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: property, trope, mode</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#ThreeDimensionalRegion -->
+    <!-- Continuant -->
 
-    <owl:Class rdf:about="&snap;ThreeDimensionalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">three_dimensional_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpatialRegion"/>
-        <owl:disjointWith rdf:resource="&snap;TwoDimensionalRegion"/>
-        <owl:disjointWith rdf:resource="&snap;ZeroDimensionalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatial region [snap:SpatialRegion] with three dimensions.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a cube-shaped part of space, a sphere-shaped part of space</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#TwoDimensionalRegion -->
-
-    <owl:Class rdf:about="&snap;TwoDimensionalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">two_dimensional_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpatialRegion"/>
-        <owl:disjointWith rdf:resource="&snap;ZeroDimensionalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatial region [snap:SpatialRegion] with two dimensions.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the surface of a cube-shaped part of space, the surface of a sphere-shaped part of space, the surface of a rectilinear planar figure-shaped part of space</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#ZeroDimensionalRegion -->
-
-    <owl:Class rdf:about="&snap;ZeroDimensionalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">zero_dimensional_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;SpatialRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatial region [snap:SpatialRegion] with no dimensions.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: a point</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ConnectedSpatiotemporalRegion -->
-
-    <owl:Class rdf:about="&span;ConnectedSpatiotemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">connected_spatiotemporal_region</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000002">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;SpatiotemporalInstant"/>
-                    <rdf:Description rdf:about="&span;SpatiotemporalInterval"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000006"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&span;SpatiotemporalRegion"/>
-        <owl:disjointWith rdf:resource="&span;ScatteredSpatiotemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatiotemporal region [span:SpatiotemporalRegion] that has temporal and spatial dimensions such that all points within the spatiotemporal region are mediately or immediately connected to all other points within the same spatiotemporal region [span:SpatiotemporalRegion].</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the spatial and temporal location of an individual organism&#39;s life, the spatial and temporal location of the development of a fetus</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ConnectedTemporalRegion -->
-
-    <owl:Class rdf:about="&span;ConnectedTemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">connected_temporal_region</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;TemporalInstant"/>
-                    <rdf:Description rdf:about="&span;TemporalInterval"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000006"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000004"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&span;TemporalRegion"/>
-        <owl:disjointWith rdf:resource="&span;ScatteredTemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A temporal region [span:TemporalRegion] every point of which is mediately or immediately connected with every other point of which.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the 1970s years, the time from the beginning to the end of a heart attack, the time taken up by cellular meiosis</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#FiatProcessPart -->
+    <!-- dependent_continuant -->
 
-    <owl:Class rdf:about="&span;FiatProcessPart">
-        <rdfs:label rdf:datatype="&xsd;string">fiat_process_part</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ProcessualEntity"/>
-        <owl:disjointWith rdf:resource="&span;Process"/>
-        <owl:disjointWith rdf:resource="&span;ProcessAggregate"/>
-        <owl:disjointWith rdf:resource="&span;ProcessBoundary"/>
-        <owl:disjointWith rdf:resource="&span;ProcessualContext"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A processual entity [span:ProcessualEntity] that is part of a process but that does not have bona fide beginnings and endings corresponding to real discontinuities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: chewing during a meal, the middle part of a rainstorm, the worst part of a heart-attack, the most interesting part of Van Gogh&#39;s life</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#Occurrent -->
-
-    <owl:Class rdf:about="&span;Occurrent">
-        <rdfs:label rdf:datatype="&xsd;string">occurrent</rdfs:label>
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/snap#DependentContinuant">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dependent_continuant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A continuant [snap:Continuant] that is either dependent on one or other independent continuant [snap:IndependentContinuant] bearers or inheres in or is borne by other entities.</rdfs:comment>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;ProcessualEntity"/>
-                    <rdf:Description rdf:about="&span;SpatiotemporalRegion"/>
-                    <rdf:Description rdf:about="&span;TemporalRegion"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000020"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&bfo;Entity"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An entity [bfo:Entity] that has temporal parts and that happens, unfolds or develops through time. Sometimes also called perdurants.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the life of an organism, a surgical operation as processual context for a nosocomical infection, the spatiotemporal context occupied by a process of cellular meiosis, the most interesting part of Van Gogh&#39;s life, the spatiotemporal region occupied by the development of a cancer tumor</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Synonyms: perdurant</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#Process -->
-
-    <owl:Class rdf:about="&span;Process">
-        <rdfs:label rdf:datatype="&xsd;string">process</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ProcessualEntity"/>
-        <owl:disjointWith rdf:resource="&span;ProcessAggregate"/>
-        <owl:disjointWith rdf:resource="&span;ProcessBoundary"/>
-        <owl:disjointWith rdf:resource="&span;ProcessualContext"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A processual entity [span:ProcessualEntity] that is a maximally connected spatiotemporal whole and has bona fide beginnings and endings corresponding to real discontinuities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the life of an organism, the process of sleeping, the process of cell-division</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ProcessAggregate -->
-
-    <owl:Class rdf:about="&span;ProcessAggregate">
-        <rdfs:label rdf:datatype="&xsd;string">process_aggregate</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ProcessualEntity"/>
-        <owl:disjointWith rdf:resource="&span;ProcessBoundary"/>
-        <owl:disjointWith rdf:resource="&span;ProcessualContext"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A processual entity [span:ProcessualEntity] that is a mereological sum of process [span:Process] entities and possesses non-connected boundaries.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the beating of the hearts of each of seven individuals in the room, the playing of each of the members of an orchestra, a process of digestion and a process of thinking taken together</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ProcessBoundary -->
-
-    <owl:Class rdf:about="&span;ProcessBoundary">
-        <rdfs:label rdf:datatype="&xsd;string">process_boundary</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ProcessualEntity"/>
-        <owl:disjointWith rdf:resource="&span;ProcessualContext"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A processual entity [span:ProcessualEntity] that is the fiat or bona fide instantaneous temporal process boundary.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: birth, death, the forming of a synapse, the onset of REM sleep, the detaching of a finger in an industrial accident, the final separation of two cells at the end of cell-division, the incision at the beginning of a surgery</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ProcessualContext -->
-
-    <owl:Class rdf:about="&span;ProcessualContext">
-        <rdfs:label rdf:datatype="&xsd;string">processual_context</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ProcessualEntity"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: An instance of a processual context [span:ProcessualContext] is a mixture of processual entity [span:ProcessualEntity] which stand as surrounding environments for other processual entity [span:ProcessualEntity] entities. The class processual context [span:ProcessualContext] is the analogous among occurrent [span:Occurrent] entities to the class site [snap:Site] among continuant [snap:Continuant] entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An occurrent [span:Occurrent] consisting of a characteristic spatial shape inhering in some arrangement of other occurrent [span:Occurrent] entities. Processual context [span:ProcessualContext] entities are characteristically entities at or in which other occurrent [span:Occurrent] entities can be located or occur.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: The processual context for a given manipulation occurring as part of an experiment is made of processual entities which occur in parallel, are not necessarily all parts of the experiment themselves and may involve continuant [snap:Continuant] entities which are in the spatial vicinity of the participants in the experiment.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#ProcessualEntity -->
-
-    <owl:Class rdf:about="&span;ProcessualEntity">
-        <rdfs:label rdf:datatype="&xsd;string">processual_entity</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;FiatProcessPart"/>
-                    <rdf:Description rdf:about="&span;Process"/>
-                    <rdf:Description rdf:about="&span;ProcessAggregate"/>
-                    <rdf:Description rdf:about="&span;ProcessBoundary"/>
-                    <rdf:Description rdf:about="&span;ProcessualContext"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000020"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&span;Occurrent"/>
-        <owl:disjointWith rdf:resource="&span;SpatiotemporalRegion"/>
-        <owl:disjointWith rdf:resource="&span;TemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An occurrent [span:Occurrent] that exists in time by occurring or happening, has temporal parts and always involves and depends on some entity.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the life of an organism, the process of meiosis, the course of a disease, the flight of a bird</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#ScatteredSpatiotemporalRegion -->
+    <!-- Disposition -->
 
-    <owl:Class rdf:about="&span;ScatteredSpatiotemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">scattered_spatiotemporal_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;SpatiotemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A spatiotemporal region [span:SpatiotemporalRegion] that has spatial and temporal dimensions and every spatial and temporal point of which is not connected with every other spatial and temporal point of which.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the space and time occupied by the individual games of the World Cup, the space and time occupied by the individual liaisons in a romantic affair</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#ScatteredTemporalRegion -->
+    <!-- FiatObjectPart -->
 
-    <owl:Class rdf:about="&span;ScatteredTemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">scattered_temporal_region</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;TemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A temporal region [span:TemporalRegion] every point of which is not mediately or immediately connected with every other point of which.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the time occupied by the individual games of the World Cup, the time occupied by the individual liaisons in a romantic affair</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000024">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInstant -->
+    <!-- Function -->
 
-    <owl:Class rdf:about="&span;SpatiotemporalInstant">
-        <rdfs:label rdf:datatype="&xsd;string">spatiotemporal_instant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ConnectedSpatiotemporalRegion"/>
-        <owl:disjointWith rdf:resource="&span;SpatiotemporalInterval"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A connected spatiotemporal region [span:ConnectedSpatiotemporalRegion] at a specific moment.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the spatiotemporal region occupied by a single instantaneous temporal slice (part) of a process</rdfs:comment>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000034">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInterval -->
+    <!-- GenericallyDependentContinuant -->
 
-    <owl:Class rdf:about="&span;SpatiotemporalInterval">
-        <rdfs:label rdf:datatype="&xsd;string">spatiotemporal_interval</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ConnectedSpatiotemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A connected spatiotemporal region [span:ConnectedSpatiotemporalRegion] that endures for more than a single moment of time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the spatiotemporal region occupied by a process or by a fiat processual part</rdfs:comment>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000031"/>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/span#SpatiotemporalRegion -->
+    <!-- IndependentContinuant -->
 
-    <owl:Class rdf:about="&span;SpatiotemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">spatiotemporal_region</rdfs:label>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000004">
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;ConnectedSpatiotemporalRegion"/>
-                    <rdf:Description rdf:about="&span;ScatteredSpatiotemporalRegion"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000140"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&span;Occurrent"/>
-        <owl:disjointWith rdf:resource="&span;TemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: All instances of occurrent [span:Occurrent] are spatiotemporal entities, that is, they enter in the relation of (spatiotemporal) location with spatiotemporal region [span:SpatiotemporalRegion] entities. As a particular case, the exact spatiotemporal location of a spatiotemporal region [span:SpatiotemporalRegion] is this region itself.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: An instance of the spatiotemporal region [span:SpatiotemporalRegion] is a part of spacetime. All parts of spacetime are spatiotemporal region [span:SpatiotemporalRegion] entities and only spatiotemporal region [span:SpatiotemporalRegion] entities are parts of spacetime. In particular, neither spatial region [snap:SpatialRegion] entities nor temporal region [span:TemporalRegion] entities are in BFO parts of spacetime. Spacetime is the entire extent of the spatiotemporal universe, a designated individual, which is thus itself a spatiotemporal region [span:SpatiotemporalRegion]. Spacetime is among occurrents the analogous of space among continuant [snap:Continuant] entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: Spacetime and spatiotemporal region [span:SpatiotemporalRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of spacetime can be called &quot;absolutist&quot; or &quot;the container view&quot;. In BFO, the class processual context [span:ProcessualContext] allows for a so-called relational view of spacetime, that is to say, a view according to which spatiotemporality is a matter of relative location between entities and not a matter of being tied to spacetime. In BFO, the bridge between these two views is secured through the fact that instances of processual context [span:ProcessualContext] are too spatiotemporal entities.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An occurrent [span:Occurrent] at or in which processual entity [span:ProcessualEntity] entities can be located.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the spatiotemporal region occupied by a human life, the spatiotemporal region occupied by the development of a cancer tumor, the spatiotemporal context occupied by a process of cellular meiosis</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#TemporalInstant -->
-
-    <owl:Class rdf:about="&span;TemporalInstant">
-        <rdfs:label rdf:datatype="&xsd;string">temporal_instant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ConnectedTemporalRegion"/>
-        <owl:disjointWith rdf:resource="&span;TemporalInterval"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A connected temporal region [span:ConnectedTemporalRegion] comprising a single moment of time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: right now, the moment at which a finger is detached in an industrial accident, the moment at which a child is born, the moment of death</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#TemporalInterval -->
-
-    <owl:Class rdf:about="&span;TemporalInterval">
-        <rdfs:label rdf:datatype="&xsd;string">temporal_interval</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&span;ConnectedTemporalRegion"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: A connected temporal region [span:ConnectedTemporalRegion] lasting for more than a single moment of time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: any continuous temporal duration during which a process occurs</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#TemporalRegion -->
-
-    <owl:Class rdf:about="&span;TemporalRegion">
-        <rdfs:label rdf:datatype="&xsd;string">temporal_region</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&span;ConnectedTemporalRegion"/>
-                    <rdf:Description rdf:about="&span;ScatteredTemporalRegion"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000140"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
                 </owl:unionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&span;Occurrent"/>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: All instances of occurrent [span:Occurrent] are temporal entities, that is, they enter in the relation of (temporal) location with temporal region [span:TemporalRegion] entities. As a particular case, the exact spatiotemporal location of a temporal region [span:TemporalRegion] is this region itself. Continuant [snap:Continuant] entities are not temporal entities in the technical sense just explained; they are related to time in a different way, not through temporal location but through a relation of existence at a time or during a period of time (see continuant [snap:Continuant].</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: An instance of temporal region [span:TemporalRegion] is a part of time. All parts of time are temporal region [span:TemporalRegion] entities and only temporal region [span:TemporalRegion] entities are parts of time. Time is the entire extent of the temporal universe, a designated individual, which is thus a temporal region itself.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Comment: Time and temporal region [span:TemporalRegion] entities are entities in their own rights which exist independently of any entities which can be located at them. This view of time can be called &quot;absolutist&quot; or &quot;the container view&quot; in analogy to what is traditionally the case with space (see spatial region [snap:SpatialRegion].</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Definition: An occurrent [span:Occurrent] that is part of time.</rdfs:comment>
-        <rdfs:comment rdf:datatype="&xsd;string">Examples: the time it takes to run a marathon, the duration of a surgical procedure, the moment of death</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000140"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000029"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
     </owl:Class>
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#Thing -->
+    <!-- MaterialEntity -->
 
-    <owl:Class rdf:about="&owl;Thing"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000024"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000030"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000027"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000027"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000024"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000030"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000030"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000024"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000027"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    </owl:Class>
+    
+
+
+    <!-- Object -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    </owl:Class>
+    
+
+
+    <!-- ObjectAggregate -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000027">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    </owl:Class>
+    
+
+
+    <!-- ObjectBoundary -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000140">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    </owl:Class>
+    
+
+
+    <!-- OneDimensionalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- Quality -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+    </owl:Class>
+    
+
+
+    <!-- RealizableEntity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+    </owl:Class>
+    
+
+
+    <!-- Role -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000017"/>
+    </owl:Class>
+    
+
+
+    <!-- Site -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000029">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
+    </owl:Class>
+    
+
+
+    <!-- SpatialRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000006">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000028"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000026"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000018"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000026"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000028"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000018"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000018"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000026"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000028"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000026"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000028"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000009"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000018"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
+    </owl:Class>
+    
+
+
+    <!-- SpecificallyDependentContinuant -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000020">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000017"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000017"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- ThreeDimensionalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000028">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- TwoDimensionalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- ZeroDimensionalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000006"/>
+    </owl:Class>
+    
+
+
+    <!-- connected_spatiotemporal_region -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#ConnectedSpatiotemporalRegion">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connected_spatiotemporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatiotemporal region [span:SpatiotemporalRegion] that has temporal and spatial dimensions such that all points within the spatiotemporal region are mediately or immediately connected to all other points within the same spatiotemporal region [span:SpatiotemporalRegion].</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the spatial and temporal location of an individual organism&apos;s life, the spatial and temporal location of the development of a fetus</rdfs:comment>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInstant"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInterval"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000011"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ScatteredSpatiotemporalRegion"/>
+    </owl:Class>
+    
+
+
+    <!-- ConnectedTemporalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000038">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
+    </owl:Class>
+    
+
+
+    <!-- fiat_process_part -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#FiatProcessPart">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fiat_process_part</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A processual entity [span:ProcessualEntity] that is part of a process but that does not have bona fide beginnings and endings corresponding to real discontinuities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: chewing during a meal, the middle part of a rainstorm, the worst part of a heart-attack, the most interesting part of Van Gogh&apos;s life</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+    </owl:Class>
+    
+
+
+    <!-- Occurrent -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000003">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000008"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000011"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000011"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000008"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000015"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000011"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000008"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000001"/>
+    </owl:Class>
+    
+
+
+    <!-- process -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#Process">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A processual entity [span:ProcessualEntity] that is a maximally connected spatiotemporal whole and has bona fide beginnings and endings corresponding to real discontinuities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the life of an organism, the process of sleeping, the process of cell-division</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+    </owl:Class>
+    
+
+
+    <!-- process_aggregate -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">process_aggregate</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A processual entity [span:ProcessualEntity] that is a mereological sum of process [span:Process] entities and possesses non-connected boundaries.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the beating of the hearts of each of seven individuals in the room, the playing of each of the members of an orchestra, a process of digestion and a process of thinking taken together</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+    </owl:Class>
+    
+
+
+    <!-- ProcessBoundary -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+    </owl:Class>
+    
+
+
+    <!-- processual_context -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessualContext">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">processual_context</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment: An instance of a processual context [span:ProcessualContext] is a mixture of processual entity [span:ProcessualEntity] which stand as surrounding environments for other processual entity [span:ProcessualEntity] entities. The class processual context [span:ProcessualContext] is the analogous among occurrent [span:Occurrent] entities to the class site [snap:Site] among continuant [snap:Continuant] entities.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: An occurrent [span:Occurrent] consisting of a characteristic spatial shape inhering in some arrangement of other occurrent [span:Occurrent] entities. Processual context [span:ProcessualContext] entities are characteristically entities at or in which other occurrent [span:Occurrent] entities can be located or occur.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: The processual context for a given manipulation occurring as part of an experiment is made of processual entities which occur in parallel, are not necessarily all parts of the experiment themselves and may involve continuant [snap:Continuant] entities which are in the spatial vicinity of the participants in the experiment.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
+    </owl:Class>
+    
+
+
+    <!-- ProcessualEntity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000015">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000035"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#FiatProcessPart"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#Process"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessAggregate"/>
+                    <rdf:Description rdf:about="http://www.ifomis.org/bfo/1.1/span#ProcessualContext"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+    </owl:Class>
+    
+
+
+    <!-- scattered_spatiotemporal_region -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#ScatteredSpatiotemporalRegion">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scattered_spatiotemporal_region</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A spatiotemporal region [span:SpatiotemporalRegion] that has spatial and temporal dimensions and every spatial and temporal point of which is not connected with every other spatial and temporal point of which.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the space and time occupied by the individual games of the World Cup, the space and time occupied by the individual liaisons in a romantic affair</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000011"/>
+    </owl:Class>
+    
+
+
+    <!-- ScatteredTemporalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000148">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000008"/>
+    </owl:Class>
+    
+
+
+    <!-- spatiotemporal_instant -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInstant">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatiotemporal_instant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A connected spatiotemporal region [span:ConnectedSpatiotemporalRegion] at a specific moment.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the spatiotemporal region occupied by a single instantaneous temporal slice (part) of a process</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/span#ConnectedSpatiotemporalRegion"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInterval"/>
+    </owl:Class>
+    
+
+
+    <!-- spatiotemporal_interval -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#SpatiotemporalInterval">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatiotemporal_interval</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A connected spatiotemporal region [span:ConnectedSpatiotemporalRegion] that endures for more than a single moment of time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: the spatiotemporal region occupied by a process or by a fiat processual part</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://www.ifomis.org/bfo/1.1/span#ConnectedSpatiotemporalRegion"/>
+    </owl:Class>
+    
+
+
+    <!-- SpatiotemporalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000011">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+    </owl:Class>
+    
+
+
+    <!-- temporal_instant -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#TemporalInstant">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal_instant</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A connected temporal region [span:ConnectedTemporalRegion] comprising a single moment of time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: right now, the moment at which a finger is detached in an industrial accident, the moment at which a child is born, the moment of death</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000038"/>
+        <owl:disjointWith rdf:resource="http://www.ifomis.org/bfo/1.1/span#TemporalInterval"/>
+    </owl:Class>
+    
+
+
+    <!-- temporal_interval -->
+
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#TemporalInterval">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal_interval</rdfs:label>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Definition: A connected temporal region [span:ConnectedTemporalRegion] lasting for more than a single moment of time.</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Examples: any continuous temporal duration during which a process occurs</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000038"/>
+    </owl:Class>
+    
+
+
+    <!-- TemporalRegion -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000008">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000038"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000148"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000148"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000038"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+    </owl:Class>
+    
+
+
+    <!-- Thing -->
+
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.2.3.1824) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
 

--- a/ontology/cheminf.owl
+++ b/ontology/cheminf.owl
@@ -1,78 +1,47 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY purl "http://purl.obofoundry.org/" >
-    <!ENTITY bfo "http://www.ifomis.org/bfo/1.1#" >
-    <!ENTITY bibo "http://purl.org/ontology/bibo/" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY obo "http://purl.obolibrary.org/obo/" >
-    <!ENTITY obo2 "http://purl.obolibrary.org/obo#" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY OBO_REL "http://purl.org/obo/owl/OBO_REL#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
-    <!ENTITY snap "http://www.ifomis.org/bfo/1.1/snap#" >
-    <!ENTITY span "http://www.ifomis.org/bfo/1.1/span#" >
-    <!ENTITY ro "http://www.obofoundry.org/ro/ro.owl#" >
-    <!ENTITY resource "http://semanticscience.org/resource/" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY ontologies "http://www.semanticweb.org/ontologies/" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY oboInOwl "http://www.geneontology.org/formats/oboInOwl#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-    <!ENTITY cheminf "http://semanticscience.org/ontology/cheminf.owl#" >
-]>
-
-
-<rdf:RDF xmlns="&ontologies;cheminf.owl#"
-     xml:base="&ontologies;cheminf.owl"
+<rdf:RDF xmlns="http://semanticscience.org/ontology/cheminf.owl#"
+     xml:base="http://semanticscience.org/ontology/cheminf.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:cheminf="http://semanticscience.org/ontology/cheminf.owl#"
-     xmlns:ro="http://www.obofoundry.org/ro/ro.owl#"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:ontologies="http://www.semanticweb.org/ontologies/"
-     xmlns:snap="http://www.ifomis.org/bfo/1.1/snap#"
-     xmlns:resource="http://semanticscience.org/resource/"
-     xmlns:bfo="http://www.ifomis.org/bfo/1.1#"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:obo2="http://purl.obolibrary.org/obo#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:cheminf-core="http://semanticscience.org/ontology/cheminf-core.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
-     xmlns:purl="http://purl.obofoundry.org/"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:cheminf1="http://www.semanticweb.org/ontologies/cheminf.owl#"
      xmlns:bibo="http://purl.org/ontology/bibo/"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:OBO_REL="http://purl.org/obo/owl/OBO_REL#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
-     xmlns:span="http://www.ifomis.org/bfo/1.1/span#">
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#">
     <owl:Ontology rdf:about="http://semanticscience.org/ontology/cheminf.owl">
-        <owl:versionInfo rdf:datatype="&xsd;string">1.0</owl:versionInfo>
-        <dc:contributor rdf:datatype="&xsd;string">Egon Willighagen</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Janna Hastings</dc:contributor>
-        <dc:contributor rdf:datatype="&xsd;string">Michel Dumontier</dc:contributor>
-        <rdfs:comment rdf:datatype="&xsd;string">The chemical information ontology (cheminf) describes information entities about chemical entities. It provides qualitative and quantitative attributes to richly describe chemicals.</rdfs:comment>
-        <dc:format rdf:datatype="&xsd;string">application/rdf+xml</dc:format>
-        <dc:title rdf:datatype="&xsd;string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
-        <dc:language rdf:datatype="&xsd;string">en</dc:language>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The chemical information ontology (cheminf) describes information entities about chemical entities. It provides qualitative and quantitative attributes to richly describe chemicals.</rdfs:comment>
         <rdfs:comment>To develop the ontology, you must change the default auto-create settings in Protege 4. Go to file&gt;preferences&gt;New Entities. Change the following:
 specified URI = http://semanticscience.org/resource/
 Followed by &apos;/&apos;, End with : AutoID
 AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
-        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
-        <dc:contributor>Cristian Munteanu</dc:contributor>
-        <dc:contributor>Gang Fu</dc:contributor>
-        <dc:contributor>Leonid Chepelev</dc:contributor>
-        <dc:contributor>Mark Davies</dc:contributor>
-        <dc:contributor>Evan Bolton</dc:contributor>
-        <dc:contributor>Colin Batchelor</dc:contributor>
-        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
-        <owl:imports rdf:resource="&obo;iao.owl"/>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <owl:imports rdf:resource="http://purl.obolibrary.org/obo/bfo/2014-05-03/classes-only.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cdk.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-algorithms.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-core.owl"/>
         <owl:imports rdf:resource="http://semanticscience.org/ontology/cheminf-external.owl"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.0</owl:versionInfo>
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+        <dc:contributor>Colin Batchelor</dc:contributor>
+        <dc:contributor>Cristian Munteanu</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egon Willighagen</dc:contributor>
+        <dc:contributor>Evan Bolton</dc:contributor>
+        <dc:contributor>Gang Fu</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Janna Hastings</dc:contributor>
+        <dc:contributor>Leonid Chepelev</dc:contributor>
+        <dc:contributor>Mark Davies</dc:contributor>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Michel Dumontier</dc:contributor>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">application/rdf+xml</dc:format>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</dc:language>
+        <dc:rights>http://creativecommons.org/licenses/by/3.0</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical information ontology (cheminf) - information entities about chemical entities</dc:title>
     </owl:Ontology>
     
 
@@ -88,149 +57,149 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+    <!-- textual definition -->
 
-    <owl:AnnotationProperty rdf:about="&obo;IAO_0000115">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
+    <!-- term editor -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000117">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+    <!-- alternative term -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000118">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
+    <!-- imported from -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000412">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/contributor -->
+    <!-- Contributor -->
 
-    <owl:AnnotationProperty rdf:about="&dc;contributor">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/description -->
+    <!-- Description -->
 
-    <owl:AnnotationProperty rdf:about="&dc;description">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/format -->
+    <!-- Format -->
 
-    <owl:AnnotationProperty rdf:about="&dc;format">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/format">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/language -->
+    <!-- Language -->
 
-    <owl:AnnotationProperty rdf:about="&dc;language">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/language">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/rights -->
+    <!-- Rights Management -->
 
-    <owl:AnnotationProperty rdf:about="&dc;rights">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/rights">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/dc/elements/1.1/title -->
+    <!-- Title -->
 
-    <owl:AnnotationProperty rdf:about="&dc;title">
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </owl:AnnotationProperty>
     
 
 
-    <!-- http://purl.org/ontology/bibo/doi -->
+    <!-- doi -->
 
-    <owl:AnnotationProperty rdf:about="&bibo;doi"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/ontology/bibo/doi"/>
     
 
 
-    <!-- http://semanticscience.org/ontology/cheminf.owl#short_name -->
+    <!-- short_name -->
 
-    <owl:AnnotationProperty rdf:about="&cheminf;short_name"/>
+    <owl:AnnotationProperty rdf:about="http://semanticscience.org/ontology/cheminf.owl#short_name"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
+    <!-- hasAlternativeId -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasAlternativeId"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+    <!-- hasDbXref -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasDbXref"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasDefinition -->
+    <!-- hasDefinition -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasDefinition"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDefinition"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
+    <!-- hasExactSynonym -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasExactSynonym"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#hasSynonym -->
+    <!-- hasSynonym -->
 
-    <owl:AnnotationProperty rdf:about="&oboInOwl;hasSynonym"/>
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasSynonym"/>
     
 
 
-    <!-- http://www.semanticweb.org/ontologies/cheminf.owl#short_name -->
+    <!-- short_name -->
 
-    <owl:AnnotationProperty rdf:about="&ontologies;cheminf.owl#short_name"/>
+    <owl:AnnotationProperty rdf:about="http://www.semanticweb.org/ontologies/cheminf.owl#short_name"/>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+    <!-- comment -->
 
-    <owl:AnnotationProperty rdf:about="&rdfs;comment"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
+    <!-- label -->
 
-    <owl:AnnotationProperty rdf:about="&rdfs;label"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
     
 
 
-    <!-- http://www.w3.org/2002/07/owl#versionInfo -->
+    <!-- versionInfo -->
 
-    <owl:AnnotationProperty rdf:about="&owl;versionInfo"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#versionInfo"/>
     
 
 
@@ -245,9 +214,9 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://www.w3.org/2001/XMLSchema#anyType -->
+    <!-- anyType -->
 
-    <rdfs:Datatype rdf:about="&xsd;anyType"/>
+    <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#anyType"/>
     
 
 
@@ -262,554 +231,34 @@ AutoID - digit count = 6, prefix = CHEMINF_</rdfs:comment>
     
 
 
-    <!-- http://purl.obolibrary.org/obo#is_enantiomer_of -->
+    <!-- is_enantiomer_of -->
 
-    <owl:ObjectProperty rdf:about="&obo2;is_enantiomer_of">
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo#is_enantiomer_of">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000461"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:propertyDisjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000463"/>
         <dc:description>A is_enantiomer_of B if and only if, given any a that instantiates A, has molecular graph ag, there is some b such that b instantiates B, is described by molecular graph bg, such that ca is equal to cb and ag is transformed into bg through a C2 symmetric transform.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000461"/>
-        <owl:propertyDisjointWith rdf:resource="&resource;CHEMINF_000463"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo#is_tautomer_of -->
+    <!-- is_tautomer_of -->
 
-    <owl:ObjectProperty rdf:about="&obo2;is_tautomer_of">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo#is_tautomer_of">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
         <dc:description>A is_tautomer_of B if and only if, given any a which instantiates A and has composition ca and is described by a molecular graph ag, there is some b that instantiates B, has composition cb and is described by a molecular graph bg, such that ca equals cb, ag is different from bg and a derives from b as the result of an intramolecular chemical transformation process (i.e. a chemical transformation process which has only one participant), in which only bonds to hydrogen are broken or formed.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
+    <!-- part_of -->
 
-    <owl:ObjectProperty rdf:about="&obo;IAO_0000136">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000047 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000047">
-        <rdfs:domain rdf:resource="&obo;IAO_0000030"/>
-        <rdfs:range rdf:resource="&obo;IAO_0000033"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000143 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000143">
-        <rdfs:domain rdf:resource="&obo;IAO_0000027"/>
-        <rdfs:range rdf:resource="&snap;SpecificallyDependentContinuant"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000145 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000145">
-        <rdfs:label>has output</rdfs:label>
-        <rdfs:domain rdf:resource="&span;Process"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_participant"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000148 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000148">
-        <rdfs:label>has input</rdfs:label>
-        <rdfs:domain rdf:resource="&span;Process"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_participant"/>
-        <rdfs:range rdf:resource="&owl;Thing"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000200 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000200">
-        <rdfs:label>has attribute</rdfs:label>
-        <rdfs:range rdf:resource="&obo;IAO_0000027"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000201"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000201 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000201">
-        <rdfs:label>is attribute of</rdfs:label>
-        <rdfs:domain rdf:resource="&obo;IAO_0000027"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000204 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000204">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
-        <rdfs:label>is variant of</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000331 -->
-
-    <rdf:Description rdf:about="&resource;CHEMINF_000331"/>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000452 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000452">
-        <rdfs:label>has_protein_binding_participant</rdfs:label>
-        <rdfs:domain rdf:resource="&obo;GO_0005515"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_participant"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000453 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000453">
-        <rdfs:label>participates_in_protein_binding</rdfs:label>
-        <rdfs:range rdf:resource="&obo;GO_0005515"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000452"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;participates_in"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000454 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000454">
-        <rdfs:label>ligates</rdfs:label>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;PR_000000001"/>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="&resource;CHEMINF_000453"/>
-            <rdf:Description rdf:about="&resource;CHEMINF_000452"/>
-        </owl:propertyChainAxiom>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000455 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000455">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label>is_isotopologue_of</rdfs:label>
-        <dc:description>An isotopologue is a molecular entity that differs only in isotopic composition from another molecular entity. (AU:I03351)</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000462"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000456 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000456">
-        <rdfs:label>has_stereoundefined_parent</rdfs:label>
-        <dc:description>Subclass relation between a class that has stereochemistry defined and an otherwise identical class that does not.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&rdfs;subClassOf"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000457 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000457">
-        <rdfs:label>has_normalized_counterpart</rdfs:label>
-        <dc:description>Connects a molecule to a normalized counterpart of the same molecule according to an algorithm.</dc:description>
-        <rdfs:comment>Caution: The number of moieties in the first molecule may be greater than in the second molecule. Example: salts.</rdfs:comment>
-        <rdfs:comment>Caution: this is not a subclass relation and should not be thought of as such for reasoning purposes.</rdfs:comment>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000458 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000458">
-        <rdfs:label>has OPS normalized counterpart</rdfs:label>
-        <dc:description>This connects a molecule to its normalized counterpart according to the OPS specification.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000457"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000459 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000459">
-        <rdfs:label>has_isotopically_unspecified_parent</rdfs:label>
-        <dc:description>Subclass relation between a class that has isotopes specified, for example D2O or 14C-urea, and an otherwise identical class that does not, for example water or urea.</dc:description>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&rdfs;subClassOf"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000460 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000460">
-        <rdfs:label>has_uncharged_counterpart</rdfs:label>
-        <dc:description>Connects a molecule to molecule with identical heavy-atom connectivity which is neutral. It is not a subclass relation.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000461 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000461">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label>is_stereoisomer_of</rdfs:label>
-        <dc:description>Connects a molecule to an isomer with identical constitution but differing in its arrangement of atoms in space. (AU:S05984)</dc:description>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000462"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000462 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000462">
-        <rdfs:label>has_same_connectivity_as</rdfs:label>
-        <dc:description>Connects a molecule to an isomer with identical constitution.</dc:description>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000463 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000463">
-        <rdfs:label>is_diastereomer_of</rdfs:label>
-        <dc:description>Connects a molecule to a stereoisomer which is not its enantiomer.</dc:description>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000461"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000477 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000477">
-        <rdfs:label>has PubChem normalized counterpart</rdfs:label>
-        <obo:IAO_0000115>This connects a molecule to its normalized counterpart according to the PubChem specification.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000457"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000478 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000478">
-        <rdfs:label>has component</rdfs:label>
-        <rdfs:comment>This connects entities at different granularities.</rdfs:comment>
-        <obo:IAO_0000115>Has as member parts (see BFO 2 Graz for more on this) many molecular entities.</obo:IAO_0000115>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000266"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;has_part"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000479 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000479">
-        <rdfs:label>has counterpart molecular entity</rdfs:label>
-        <rdfs:comment>This is intended to capture the case where a database has ad hoc relations between molecules that are not necessarily subclass relations.</rdfs:comment>
-        <obo:IAO_0000115>Connects a molecular entity to another molecular entity according to some specification.</obo:IAO_0000115>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000480 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000480">
-        <rdfs:label>has component with uncharged counterpart</rdfs:label>
-        <obo:IAO_0000115>Connects a molecular substance, say a mixture containing ions, with a neutral form of one of the ions.</obo:IAO_0000115>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&resource;CHEMINF_000266"/>
-        <owl:propertyChainAxiom rdf:parseType="Collection">
-            <rdf:Description rdf:about="&resource;CHEMINF_000478"/>
-            <rdf:Description rdf:about="&resource;CHEMINF_000460"/>
-        </owl:propertyChainAxiom>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000481 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000481">
-        <rdfs:label>similar to</rdfs:label>
-        <rdfs:comment>not transitive, obviously</rdfs:comment>
-        <obo:IAO_0000115>Connects a molecular entity that is deemed similar to another according to some algorithm.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000482 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000482">
-        <rdfs:label>similar to by PubChem 2D similarity algorithm</rdfs:label>
-        <rdfs:comment>http://pubchem.ncbi.nlm.nih.gov/help.html#tanimoto</rdfs:comment>
-        <obo:IAO_0000115>Has a Tanimoto score with the counterpart molecular entity of more than 0.9, based on the PubChem fingerprint specification.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000481"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000483 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000483">
-        <rdfs:label>similar to by PubChem 3D similarity algorithm</rdfs:label>
-        <rdfs:comment>http://dx.doi.org/10.1186/1758-2946-3-32</rdfs:comment>
-        <obo:IAO_0000115>Has a 3D Tanimoto score with the counterpart molecule where the 3D shape similarity for the two is greater than 0.795 and the 3D feature score is greater than 0.495 or there are no features and the 3D shape similarity is greater than 0.925, where the shape similarity ST is calculated by ST=VAB/(VAA+VBB-VAB), where VAA and VBB are self-overlap volume of conformers A and B, and VAB is the common overlap volume between them and the feature score CT is calculated by CT=sum(VfAB)/(sum(VfAA)+sum(VfBB)-sum(VfAB)), where the superscript f indicates any of the six independent fictitious feature atom types, VfAA and VfBB are the respective self-overlap volumes of conformers A and B for feature atom type f, and VfAB is the overlap volume of conformers A and B for feature type f.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000481"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000486 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000486">
-        <rdfs:label>has major tautomer at pH 7.4</rdfs:label>
-        <obo:IAO_0000115>A exists in an equilibrium with B at pH 7.4 and physiological temperature and B is the dominant isomer.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&obo2;is_tautomer_of"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000489 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000489">
-        <rdfs:label xml:lang="en">is_isotopically_unspecified_parent_of</rdfs:label>
-        <dc:description>Superclass relation between a class does not have isotopes specified, such as water or urea, and a class that does, such as D2O or 14C-urea.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000459"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000491 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000491">
-        <rdfs:label xml:lang="en">is_stereoundefined_parent_of</rdfs:label>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <dc:description>Superclass relation between a class that does not have stereochemistry defined and another otherwise identical one that does.</dc:description>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000456"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000492 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000492">
-        <rdfs:label xml:lang="en">is component with uncharged counterpart of</rdfs:label>
-        <rdfs:comment>This is here because Open PHACTS has requested an inverse. Use with caution!</rdfs:comment>
-        <obo:IAO_0000115>Connects a neutral molecule with a salt.</obo:IAO_0000115>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000480"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000493 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000493">
-        <rdfs:label xml:lang="en">is major tautomer at pH 7.4 of</rdfs:label>
-        <obo:IAO_0000115>A exists in an equilibrium with B at pH 7.4 and physiological temperature and A is the dominant isomer.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&obo2;is_tautomer_of"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000486"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000494 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000494">
-        <rdfs:label xml:lang="en">is OPS normalized counterpart of</rdfs:label>
-        <obo:IAO_0000115>If A &apos;is OPS normalized counterpart of&apos; B, then A is the molecular entity corresponding to the connection table obtained by applying OPS normalization to the connection table of B.</obo:IAO_0000115>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000458"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000495 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000495">
-        <rdfs:label xml:lang="en">is uncharged counterpart of</rdfs:label>
-        <obo:IAO_0000115>If A &apos;is uncharged counterpart of&apos; B, then A is the neutral species corresponding to B. B may itself of course be neutral.</obo:IAO_0000115>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000460"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000497 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000497">
-        <rdfs:label xml:lang="en">is counterpart with different charge of</rdfs:label>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <obo:IAO_0000115>If A &apos;is a counterpart with different charge of&apos; B, then A is an otherwise identical species to B but for charge.</obo:IAO_0000115>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000462"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000498 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000498">
-        <rdf:type rdf:resource="&owl;SymmetricProperty"/>
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">shares OPS normalized parent with</rdfs:label>
-        <obo:IAO_0000115>If A &apos;shares OPS normalized parent with&apos; B,
-then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normalized counterpart&apos; C.</obo:IAO_0000115>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000479"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000499 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000499">
-        <rdfs:label xml:lang="en">has ChemAxon canonicalised tautomer</rdfs:label>
-        <rdfs:comment>A and B can be identical.</rdfs:comment>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <obo:IAO_0000115>If A &apos;has ChemAxon canonicalised tautomer&apos; B then B is the molecular entity corresponding to the output of ChemAxon&apos;s canonical tautomer generation algorithm applied to the connection table of A.</obo:IAO_0000115>
-        <rdfs:subPropertyOf rdf:resource="&obo2;is_tautomer_of"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000514 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000514">
-        <rdfs:label xml:lang="en">is ChemAxon canonicalised tautomer of</rdfs:label>
-        <obo:IAO_0000115>If B &apos;has ChemAxon canonicalised tautomer&apos; A then B is the molecular entity corresponding to the output of ChemAxon&apos;s canonical tautomer generation algorithm applied to the connection table of A.</obo:IAO_0000115>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
-        <rdfs:comment>A and B can be identical.</rdfs:comment>
-        <rdfs:subPropertyOf rdf:resource="&obo2;is_tautomer_of"/>
-        <rdfs:domain rdf:resource="&obo;CHEBI_23367"/>
-        <rdfs:range rdf:resource="&obo;CHEBI_23367"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000499"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000606 -->
-
-    <owl:ObjectProperty rdf:about="&resource;CHEMINF_000606">
-        <rdfs:domain rdf:resource="&obo;IAO_0000027"/>
-        <rdfs:range rdf:resource="&obo;IAO_0000064"/>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000331"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_agent -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_agent">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_part -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_part"/>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#has_participant -->
-
-    <owl:ObjectProperty rdf:about="&ro;has_participant">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.obofoundry.org/ro/ro.owl#part_of -->
-
-    <rdf:Description rdf:about="&ro;part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -835,19 +284,558 @@ then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normaliz
     
 
 
-    <!-- http://www.semanticweb.org/ontologies/is_output_of -->
+    <!-- has_part -->
 
-    <owl:ObjectProperty rdf:about="&ontologies;is_output_of">
-        <rdfs:label>is output of</rdfs:label>
-        <owl:inverseOf rdf:resource="&resource;CHEMINF_000145"/>
-        <rdfs:subPropertyOf rdf:resource="&ro;participates_in"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051"/>
+    
+
+
+    <!-- is about -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000136">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#subClassOf -->
+    <!-- has_participant -->
 
-    <owl:ObjectProperty rdf:about="&rdfs;subClassOf"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_agent -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002218">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- conforms to -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000047">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is descriptor of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000143">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has output -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000145">
+        <rdfs:label>has output</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <rdfs:domain rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
+        <owl:inverseOf rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has input -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000148">
+        <rdfs:label>has input</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <rdfs:domain rdf:resource="http://www.ifomis.org/bfo/1.1/span#Process"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has attribute -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000200">
+        <rdfs:label>has attribute</rdfs:label>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000201"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is attribute of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000201">
+        <rdfs:label>is attribute of</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is variant of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000204">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:label>is variant of</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- should execute with output -->
+
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000331">
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+    </rdf:Description>
+    
+
+
+    <!-- has_protein_binding_participant -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000452">
+        <rdfs:label>has_protein_binding_participant</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/GO_0005515"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000453"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- participates_in_protein_binding -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000453">
+        <rdfs:label>participates_in_protein_binding</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/GO_0005515"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- ligates -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000454">
+        <rdfs:label>ligates</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000453"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000452"/>
+        </owl:propertyChainAxiom>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is_isotopologue_of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000455">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label>is_isotopologue_of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000462"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <dc:description>An isotopologue is a molecular entity that differs only in isotopic composition from another molecular entity. (AU:I03351)</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_stereoundefined_parent -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000456">
+        <rdfs:label>has_stereoundefined_parent</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000491"/>
+        <dc:description>Subclass relation between a class that has stereochemistry defined and an otherwise identical class that does not.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_normalized_counterpart -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000457">
+        <rdfs:label>has_normalized_counterpart</rdfs:label>
+        <rdfs:comment>Caution: The number of moieties in the first molecule may be greater than in the second molecule. Example: salts.</rdfs:comment>
+        <rdfs:comment>Caution: this is not a subclass relation and should not be thought of as such for reasoning purposes.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <dc:description>Connects a molecule to a normalized counterpart of the same molecule according to an algorithm.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has OPS normalized counterpart -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000458">
+        <rdfs:label>has OPS normalized counterpart</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000457"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000494"/>
+        <dc:description>This connects a molecule to its normalized counterpart according to the OPS specification.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_isotopically_unspecified_parent -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000459">
+        <rdfs:label>has_isotopically_unspecified_parent</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000489"/>
+        <dc:description>Subclass relation between a class that has isotopes specified, for example D2O or 14C-urea, and an otherwise identical class that does not, for example water or urea.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_uncharged_counterpart -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000460">
+        <rdfs:label>has_uncharged_counterpart</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000495"/>
+        <dc:description>Connects a molecule to molecule with identical heavy-atom connectivity which is neutral. It is not a subclass relation.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is_stereoisomer_of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000461">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label>is_stereoisomer_of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000462"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <dc:description>Connects a molecule to an isomer with identical constitution but differing in its arrangement of atoms in space. (AU:S05984)</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_same_connectivity_as -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000462">
+        <rdfs:label>has_same_connectivity_as</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <dc:description>Connects a molecule to an isomer with identical constitution.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is_diastereomer_of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000463">
+        <rdfs:label>is_diastereomer_of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000461"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <dc:description>Connects a molecule to a stereoisomer which is not its enantiomer.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has PubChem normalized counterpart -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000477">
+        <rdfs:label>has PubChem normalized counterpart</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000457"/>
+        <obo:IAO_0000115>This connects a molecule to its normalized counterpart according to the PubChem specification.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has component -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000478">
+        <rdfs:label>has component</rdfs:label>
+        <rdfs:comment>This connects entities at different granularities.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000115>Has as member parts (see BFO 2 Graz for more on this) many molecular entities.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has counterpart molecular entity -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000479">
+        <rdfs:label>has counterpart molecular entity</rdfs:label>
+        <rdfs:comment>This is intended to capture the case where a database has ad hoc relations between molecules that are not necessarily subclass relations.</rdfs:comment>
+        <obo:IAO_0000115>Connects a molecular entity to another molecular entity according to some specification.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has component with uncharged counterpart -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000480">
+        <rdfs:label>has component with uncharged counterpart</rdfs:label>
+        <rdfs:domain rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000492"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000478"/>
+            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000460"/>
+        </owl:propertyChainAxiom>
+        <obo:IAO_0000115>Connects a molecular substance, say a mixture containing ions, with a neutral form of one of the ions.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- similar to -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000481">
+        <rdfs:label>similar to</rdfs:label>
+        <rdfs:comment>not transitive, obviously</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <obo:IAO_0000115>Connects a molecular entity that is deemed similar to another according to some algorithm.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- similar to by PubChem 2D similarity algorithm -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000482">
+        <rdfs:label>similar to by PubChem 2D similarity algorithm</rdfs:label>
+        <rdfs:comment>http://pubchem.ncbi.nlm.nih.gov/help.html#tanimoto</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000481"/>
+        <obo:IAO_0000115>Has a Tanimoto score with the counterpart molecular entity of more than 0.9, based on the PubChem fingerprint specification.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- similar to by PubChem 3D similarity algorithm -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000483">
+        <rdfs:label>similar to by PubChem 3D similarity algorithm</rdfs:label>
+        <rdfs:comment>http://dx.doi.org/10.1186/1758-2946-3-32</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000481"/>
+        <obo:IAO_0000115>Has a 3D Tanimoto score with the counterpart molecule where the 3D shape similarity for the two is greater than 0.795 and the 3D feature score is greater than 0.495 or there are no features and the 3D shape similarity is greater than 0.925, where the shape similarity ST is calculated by ST=VAB/(VAA+VBB-VAB), where VAA and VBB are self-overlap volume of conformers A and B, and VAB is the common overlap volume between them and the feature score CT is calculated by CT=sum(VfAB)/(sum(VfAA)+sum(VfBB)-sum(VfAB)), where the superscript f indicates any of the six independent fictitious feature atom types, VfAA and VfBB are the respective self-overlap volumes of conformers A and B for feature atom type f, and VfAB is the overlap volume of conformers A and B for feature type f.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has major tautomer at pH 7.4 -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000486">
+        <rdfs:label>has major tautomer at pH 7.4</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo#is_tautomer_of"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000493"/>
+        <obo:IAO_0000115>A exists in an equilibrium with B at pH 7.4 and physiological temperature and B is the dominant isomer.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is_isotopically_unspecified_parent_of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000489">
+        <rdfs:label xml:lang="en">is_isotopically_unspecified_parent_of</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>Superclass relation between a class does not have isotopes specified, such as water or urea, and a class that does, such as D2O or 14C-urea.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is_stereoundefined_parent_of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000491">
+        <rdfs:label xml:lang="en">is_stereoundefined_parent_of</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>Superclass relation between a class that does not have stereochemistry defined and another otherwise identical one that does.</dc:description>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is component with uncharged counterpart of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000492">
+        <rdfs:label xml:lang="en">is component with uncharged counterpart of</rdfs:label>
+        <rdfs:comment>This is here because Open PHACTS has requested an inverse. Use with caution!</rdfs:comment>
+        <obo:IAO_0000115>Connects a neutral molecule with a salt.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is major tautomer at pH 7.4 of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000493">
+        <rdfs:label xml:lang="en">is major tautomer at pH 7.4 of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo#is_tautomer_of"/>
+        <obo:IAO_0000115>A exists in an equilibrium with B at pH 7.4 and physiological temperature and A is the dominant isomer.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is OPS normalized counterpart of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000494">
+        <rdfs:label xml:lang="en">is OPS normalized counterpart of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <obo:IAO_0000115>If A &apos;is OPS normalized counterpart of&apos; B, then A is the molecular entity corresponding to the connection table obtained by applying OPS normalization to the connection table of B.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is uncharged counterpart of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000495">
+        <rdfs:label xml:lang="en">is uncharged counterpart of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <obo:IAO_0000115>If A &apos;is uncharged counterpart of&apos; B, then A is the neutral species corresponding to B. B may itself of course be neutral.</obo:IAO_0000115>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is counterpart with different charge of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000497">
+        <rdfs:label xml:lang="en">is counterpart with different charge of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000462"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000115>If A &apos;is a counterpart with different charge of&apos; B, then A is an otherwise identical species to B but for charge.</obo:IAO_0000115>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- shares OPS normalized parent with -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000498">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">shares OPS normalized parent with</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000479"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000115>If A &apos;shares OPS normalized parent with&apos; B,
+then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normalized counterpart&apos; C.</obo:IAO_0000115>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has ChemAxon canonicalised tautomer -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000499">
+        <rdfs:label xml:lang="en">has ChemAxon canonicalised tautomer</rdfs:label>
+        <rdfs:comment>A and B can be identical.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo#is_tautomer_of"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <owl:inverseOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000514"/>
+        <obo:IAO_0000115>If A &apos;has ChemAxon canonicalised tautomer&apos; B then B is the molecular entity corresponding to the output of ChemAxon&apos;s canonical tautomer generation algorithm applied to the connection table of A.</obo:IAO_0000115>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is ChemAxon canonicalised tautomer of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000514">
+        <rdfs:label xml:lang="en">is ChemAxon canonicalised tautomer of</rdfs:label>
+        <rdfs:comment>A and B can be identical.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo#is_tautomer_of"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+        <obo:IAO_0000115>If B &apos;has ChemAxon canonicalised tautomer&apos; A then B is the molecular entity corresponding to the output of ChemAxon&apos;s canonical tautomer generation algorithm applied to the connection table of A.</obo:IAO_0000115>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- is execution output of -->
+
+    <owl:ObjectProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000606">
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- has_agent -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002218"/>
+    
+
+
+    <!-- has_participant -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0000057"/>
+    
+
+
+    <!-- part_of -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+    
+
+
+    <!-- is output of -->
+
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/ontologies/is_output_of">
+        <rdfs:label>is output of</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- subClassOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
     
 
 
@@ -862,55 +850,55 @@ then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normaliz
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000004 -->
+    <!-- has measurement value -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000004">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000404 -->
+    <!-- has x coordinate value -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000404">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000404">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000405 -->
+    <!-- has z coordinate value -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000405">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000405">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000406 -->
+    <!-- has y coordinate value -->
 
-    <owl:DatatypeProperty rdf:about="&obo;IAO_0000406">
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
+    <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000406">
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000009 -->
+    <!-- has uncertainty value -->
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000009">
-        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000009">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:label>has uncertainty value</rdfs:label>
-        <rdfs:domain rdf:resource="&obo;IAO_0000030"/>
-        <rdfs:subPropertyOf rdf:resource="&resource;CHEMINF_000012"/>
-        <rdfs:range rdf:resource="&xsd;float"/>
+        <rdfs:subPropertyOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
     </owl:DatatypeProperty>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000012 -->
+    <!-- has value -->
 
-    <owl:DatatypeProperty rdf:about="&resource;CHEMINF_000012">
+    <owl:DatatypeProperty rdf:about="http://semanticscience.org/resource/CHEMINF_000012">
         <rdfs:label>has value</rdfs:label>
-        <rdfs:domain rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
     </owl:DatatypeProperty>
     
 
@@ -926,314 +914,364 @@ then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normaliz
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CHEBI_23367 -->
+    <!-- disposition -->
 
-    <owl:Class rdf:about="&obo;CHEBI_23367"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000016"/>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000010 -->
+    <!-- quality -->
 
-    <owl:Class rdf:about="&obo;IAO_0000010">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000019"/>
+    
+
+
+    <!-- specifically_dependent_continuant -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000020"/>
+    
+
+
+    <!-- material_entity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    
+
+
+    <!-- molecular entity -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+    
+
+
+    <!-- software -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000010">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000027 -->
+    <!-- data item -->
 
-    <owl:Class rdf:about="&obo;IAO_0000027">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000027">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
+    <!-- information content entity -->
 
-    <owl:Class rdf:about="&obo;IAO_0000030">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000033 -->
+    <!-- directive information entity -->
 
-    <owl:Class rdf:about="&obo;IAO_0000033">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000033">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000064 -->
+    <!-- algorithm -->
 
-    <owl:Class rdf:about="&obo;IAO_0000064">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000064">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
         <oboInOwl:hasAlternativeId>BODO:Algorithm</oboInOwl:hasAlternativeId>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000098 -->
+    <!-- data format specification -->
 
-    <owl:Class rdf:about="&obo;IAO_0000098">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000098">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000104 -->
+    <!-- plan specification -->
 
-    <owl:Class rdf:about="&obo;IAO_0000104">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000104">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000109 -->
+    <!-- measurement datum -->
 
-    <owl:Class rdf:about="&obo;IAO_0000109">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000109">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000310 -->
+    <!-- document -->
 
-    <owl:Class rdf:about="&obo;IAO_0000310">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000310">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000579 -->
+    <!-- centrally registered identifier registry -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000579">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000579">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0000011 -->
+    <!-- planned process -->
 
-    <owl:Class rdf:about="&obo;OBI_0000011">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0000011">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000000 -->
+    <!-- chemical entity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000000">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000000">
         <rdfs:label>chemical entity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;MaterialEntity"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
         <dc:description>A chemical entity is any molecular entity or chemical substance.</dc:description>
         <oboInOwl:hasAlternativeId>obo:24431</oboInOwl:hasAlternativeId>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000014 -->
+    <!-- chemical entity information format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000014">
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000098"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000098"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000017 -->
+    <!-- information about a chemical entity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000017">
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000030"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000044 -->
+    <!-- preferred name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000044">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000044">
         <owl:equivalentClass>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000472"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000472"/>
             </owl:Restriction>
         </owl:equivalentClass>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000057 -->
+    <!-- file -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000057">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000057">
         <rdfs:label>file</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000310"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000310"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000058 -->
+    <!-- MOLfile -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000058">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000057"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000058">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000057"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000065 -->
+    <!-- molecular entity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000065"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000065"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000085 -->
+    <!-- structural descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000085"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000085"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000086 -->
+    <!-- chemical quality -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000086">
-        <rdfs:subClassOf rdf:resource="&snap;Quality"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000086">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000089 -->
+    <!-- polarizability -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000089">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000089">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000103 -->
+    <!-- software module to calculate a chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000103">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000340"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000103">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000340"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000121 -->
+    <!-- electronegativity -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000121">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000121">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000123 -->
+    <!-- chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000123">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000123">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000143"/>
-                <owl:someValuesFrom rdf:resource="&snap;SpecificallyDependentContinuant"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000143"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000020"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000138 -->
+    <!-- software execution -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000138">
-        <rdfs:subClassOf rdf:resource="&obo;OBI_0000011"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000138">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000343"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000343"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000139 -->
+    <!-- software implementation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000139">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000139">
         <rdfs:label>software implementation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000010"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000010"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000140 -->
+    <!-- PubChem compound identifier (CID) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000140">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000140">
         <rdfs:label>PubChem compound identifier (CID)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000302"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000141 -->
+    <!-- PubChem substance identifier (SID) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000141">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000141">
         <rdfs:label>PubChem substance identifier (SID)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000302"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000302"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000142 -->
+    <!-- Pipeline Pilot library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000142">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000142">
         <rdfs:label>Pipeline Pilot library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://accelrys.com/products/pipeline-pilot/</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000144 -->
+    <!-- algorithm to calculate a chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000144">
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000064"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000147 -->
+    <!-- parameterized software execution -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000147">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000147">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000148"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000500"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000145"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000145"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000027"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000148"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000500"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000198 -->
+    <!-- molecular weight calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000198">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000198">
         <rdfs:label>molecular weight calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000216"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000216"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1249,19 +1287,19 @@ then A &apos;has OPS normalized counterpart&apos; C and B &apos;has OPS normaliz
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000211 -->
+    <!-- dimensional extent quality -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000211">
-        <rdfs:subClassOf rdf:resource="&snap;Quality"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000221 -->
+    <!-- Ghose/Crippen ALogP calculation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000221">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000221">
         <rdfs:label>Ghose/Crippen ALogP calculation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000450"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000450"/>
         <obo:IAO_0000115>Fragment Method used for the calculation of ALogP as defined by Ghose and Crippen. 
 
 Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (Lipophilic) Properties of Small Organic Molecules Using Fragment Methods: An Analysis of AlogP and CLogP Methods. J. Phys. Chem. A, 1998, 102, 3762-3772.
@@ -1271,101 +1309,132 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000228 -->
+    <!-- refractive index -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000228">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000228">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000234 -->
+    <!-- PubChem conformer identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000234">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000140"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000234">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000140"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000238 -->
+    <!-- meltability -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000238">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000238">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
         <oboInOwl:hasSynonym>fusibility</oboInOwl:hasSynonym>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000248 -->
+    <!-- relative permittivity -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000248">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000248">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000255 -->
+    <!-- vaporizability -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000255">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000404"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000255">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000404"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000266 -->
+    <!-- chemical substance -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000266"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000266"/>
     
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000302 -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000302">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <!-- PubMed Identifier -->
+
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000302">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000303 -->
+    <!-- GenBank Protein Identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000303">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000303">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000304 -->
+    <!-- GenBank Nucleotide Identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000304">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000304">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000305 -->
+    <!-- ALogP calculated by Pipeline Pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000305">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000305">
         <rdfs:label>ALogP calculated by Pipeline Pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000295"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000295"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000221"/>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000221"/>
                                             </owl:Restriction>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000142"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000142"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000142"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000221"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1380,51 +1449,81 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000306 -->
+    <!-- Ertl polar surface area calculation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000306">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000306">
         <rdfs:label>Ertl polar surface area calculation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000450"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000450"/>
         <obo:IAO_0000115>Fast calculation of molecular polar surface area as a sum of fragment based contributions and its application to the prediction of drug transport properties, Ertl, P., Rohde, B., Selzer, P., J. Med. Chem. 2000, 43, 3714-3717.
 </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000307 -->
+    <!-- polar surface area descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000307">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000307">
         <rdfs:label>polar surface area descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000229"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000229"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000308 -->
+    <!-- polar surface area descriptor calculated by Pipeline Pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000308">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000308">
         <rdfs:label>polar surface area descriptor calculated by Pipeline Pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000307"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000307"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000306"/>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000306"/>
                                             </owl:Restriction>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000306"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1439,27 +1538,53 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000309 -->
+    <!-- hydrogen bond acceptor count calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000309">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000309">
         <rdfs:label>hydrogen bond acceptor count calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000245"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000245"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1474,27 +1599,53 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000310 -->
+    <!-- hydrogen bond donor count calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000310">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000310">
         <rdfs:label>hydrogen bond donor count calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000244"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000244"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1509,27 +1660,53 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000311 -->
+    <!-- rotatable bond count calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000311">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000311">
         <rdfs:label>rotatable bond count calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000254"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000254"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1544,11 +1721,11 @@ Ghose, A.K., Viswanadhan V.N., and Wendoloski, J.J., Prediction of Hydrophobic (
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000312 -->
+    <!-- rule of five violations descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000312">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000312">
         <rdfs:label>rule of five violations descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>Number of properties defined in Lipinski’s Rule of 5 (RO5) that the compound fails.  Conditions which violate the RO5 are:
 Molecular weight&gt;=500
 AlogP&gt;=5
@@ -1559,41 +1736,71 @@ HBA&gt;=10
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000313 -->
+    <!-- Lipinski rule of five violation calculation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000313">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000313">
         <rdfs:label>Lipinski rule of five violation calculation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000450"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000450"/>
         <obo:IAO_0000115>Lipinski, C. A.; Lombardo, F.; Dominy, B. W.; Feeney, P. J. Experimental and Computational Approaches to Estimate Solubility and Permeability in Drug Discovery and Development Settings. Adv. Drug Deliv. Rev., 1997, 23, 3-25.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000314 -->
+    <!-- rule of five violations calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000314">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000314">
         <rdfs:label>rule of five violations calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000312"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000313"/>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000313"/>
                                             </owl:Restriction>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000313"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1608,11 +1815,11 @@ HBA&gt;=10
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000315 -->
+    <!-- rule of three passes descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000315">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000315">
         <rdfs:label>rule of three passes descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>Rule of 3 passes.  It is suggested that compounds that pass all these criteria are more likely to be hits in fragment screening.
 molecular weight &lt;=300, 
 number of hydrogen bond donors &lt;=3, 
@@ -1625,11 +1832,11 @@ PSA&lt;=60
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000316 -->
+    <!-- rule of three passes calculation algorithm -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000316">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000316">
         <rdfs:label>rule of three passes calculation algorithm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000450"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000450"/>
         <obo:IAO_0000115>A ‘Rule of Three’ for fragment-based lead discovery? Miles Congreve, Robin Carr,
 Chris Murray and Harren Jhoti. Drug Discovery Today, 2003,8(19), 876-877
 </obo:IAO_0000115>
@@ -1637,31 +1844,61 @@ Chris Murray and Harren Jhoti. Drug Discovery Today, 2003,8(19), 876-877
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000317 -->
+    <!-- rule of three passes calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000317">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000317">
         <rdfs:label>rule of three passes calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000315"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000315"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000316"/>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000316"/>
                                             </owl:Restriction>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000316"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1676,11 +1913,11 @@ Chris Murray and Harren Jhoti. Drug Discovery Today, 2003,8(19), 876-877
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000318 -->
+    <!-- medchem friendly descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000318">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000318">
         <rdfs:label>medchem friendly descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>MedChem Friendly
 These are functional groups that may not be desirable from a medicinal chemistry perspective.  For example reactive groups will be flagged as “N” (not MedChem Friendly).  Molecules which do not contain any of these groups will be flagged as “Y” (MedChem Friendly).
 The groups are defined by the following list of SMARTS:
@@ -1709,27 +1946,53 @@ SC#N
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000319 -->
+    <!-- medchem friendly descriptor calculated by pipeline pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000319">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000319">
         <rdfs:label>medchem friendly descriptor calculated by pipeline pilot</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000318"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000318"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000329"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000329"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1744,50 +2007,50 @@ SC#N
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000320 -->
+    <!-- ACD/Labs PhysChem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000320">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000320">
         <rdfs:label>ACD/Labs PhysChem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://www.acdlabs.com/resources/knowledgebase/app_notes/physchem/</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000321 -->
+    <!-- logP calculated by ACD/Labs PhysChem software -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000321">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000321">
         <rdfs:label>logP calculated by ACD/Labs PhysChem software</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000251"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000251"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000322 -->
+    <!-- logD descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000322">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000322">
         <rdfs:label>logD descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>octanol-water distribution coefficient calculated at a given pH. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000323 -->
+    <!-- logD calculated at pH 7.4 by ACD/Labs PhysChem software -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000323">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000323">
         <rdfs:label>logD calculated at pH 7.4 by ACD/Labs PhysChem software</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000322"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000322"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>ACD_LogD(pH7.4)
@@ -1796,27 +2059,53 @@ Distribution Coefficient calculated at pH7.4</obo:IAO_0000115>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000324 -->
+    <!-- most acidic pKa calculated by ACD/Labs PhysChem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000324">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000324">
         <rdfs:label>most acidic pKa calculated by ACD/Labs PhysChem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000195"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000195"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_agent"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002218"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000328"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002218"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -1833,36 +2122,36 @@ Distribution Coefficient calculated at pH7.4</obo:IAO_0000115>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000325 -->
+    <!-- most basic pKa calculated by ACD/Labs PhysChem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000325">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000325">
         <rdfs:label>most basic pKa calculated by ACD/Labs PhysChem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000195"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000195"/>
         <obo:IAO_0000115>Most basic pKa of the molecule
 </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000326 -->
+    <!-- molecular species at pH 7.4 descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000326">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000326">
         <rdfs:label>molecular species at pH 7.4 descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>Molecular Species is a description of the predominant form of the molecule at pH7.4.  </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000327 -->
+    <!-- molecular species at pH 7.4 calculated by ACD/Labs PhysChem software -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000327">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000327">
         <rdfs:label>molecular species at pH 7.4 calculated by ACD/Labs PhysChem software</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000326"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000326"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>These are defined  according to the definitions:
@@ -1875,310 +2164,90 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000328 -->
+    <!-- ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000328">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000328">
         <rdfs:label>ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000320"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000320"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000329 -->
+    <!-- Pipeline Pilot Server Version 8.5.0 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000329">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000329">
         <rdfs:label>Pipeline Pilot Server Version 8.5.0</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000142"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000142"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000332 -->
+    <!-- PubChem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000332">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000332">
         <rdfs:label xml:lang="en">PubChem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://pubchem.ncbi.nlm.nih.gov/help.html</obo:IAO_0000115>
     </owl:Class>
     
-    <!-- http://semanticscience.org/resource/CHEMINF_000800 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000800">
-        <rdfs:label xml:lang="en">RDKit software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
-        <obo:IAO_0000115>http://www.rdkit.org/</obo:IAO_0000115>
-    </owl:Class>
 
-	<!-- http://semanticscience.org/resource/CHEMINF_000801 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000801">
-        <rdfs:label xml:lang="en">RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000800"/>
-        <obo:IAO_0000115>http://www.rdkit.org/</obo:IAO_0000115>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000802 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000802">
-        <rdfs:label xml:lang="en">number of rule of five violations calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000312"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000803 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000803">
-        <rdfs:label xml:lang="en">hydrogen bond acceptor count calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000245"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000804 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000804">
-        <rdfs:label xml:lang="en">hydrogen bond donor count calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000244"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000805 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000805">
-        <rdfs:label xml:lang="en">logP descriptor calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000251"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000806 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000806">
-        <rdfs:label xml:lang="en">molecular formula calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000042"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000807 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000807">
-        <rdfs:label xml:lang="en">average molecular weight calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000216"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-	
-	<!-- http://semanticscience.org/resource/CHEMINF_000808 -->
-    
-    <owl:Class rdf:about="&resource;CHEMINF_000808">
-        <rdfs:label xml:lang="en">total polar surface area calculated by RDKit software library version 2015_09_2</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000307"/>
-		<rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom>
-                    <owl:Class>
-                        <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                                <owl:someValuesFrom>
-                                    <owl:Class>
-                                        <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
-                                            <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000801"/>
-                                            </owl:Restriction>
-                                        </owl:intersectionOf>
-                                    </owl:Class>
-                                </owl:someValuesFrom>
-                            </owl:Restriction>
-                        </owl:intersectionOf>
-                    </owl:Class>
-                </owl:someValuesFrom>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
 
-   
-    <!-- http://semanticscience.org/resource/CHEMINF_000333 -->
+    <!-- PubChem software library version 2.1 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000333">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000333">
         <rdfs:label xml:lang="en">PubChem software library version 2.1</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000332"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000332"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000334 -->
+    <!-- molecular weight calculated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000334">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000334">
         <rdfs:label xml:lang="en">molecular weight calculated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000216"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000216"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2193,27 +2262,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000335 -->
+    <!-- molecular formula calculated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000335">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000335">
         <rdfs:label xml:lang="en">molecular formula calculated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000042"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000042"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2228,27 +2323,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000336 -->
+    <!-- total formal charge calculated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000336">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000336">
         <rdfs:label xml:lang="en">total formal charge calculated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000268"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000268"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2263,27 +2384,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000337 -->
+    <!-- monoisotopic mass calculated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000337">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000337">
         <rdfs:label xml:lang="en">monoisotopic mass calculated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000218"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000218"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2298,27 +2445,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000338 -->
+    <!-- exact mass calculated by pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000338">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000338">
         <rdfs:label xml:lang="en">exact mass calculated by pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000217"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000217"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2333,54 +2506,54 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000339 -->
+    <!-- pubchem depositor-supplied molecular entity name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000339">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000339">
         <rdfs:label xml:lang="en">pubchem depositor-supplied molecular entity name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <obo:IAO_0000115>A molecular entity name that has been supplied by a depositor to the PubChem database. This is just a molecular entity name with additional provenance associated. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000340 -->
+    <!-- software module -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000340">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000340">
         <rdfs:label>software module</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000139"/>
+        <rdfs:comment>Is this equivalent to IAO &apos;source code module&apos; (IAO_0000096) on the same level as &apos;software&apos;? From the textual definition in IAO it seems fairly close. (JH)</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000139"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_part"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000341"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000341"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A software module is a collection of software methods.</dc:description>
-        <rdfs:comment>Is this equivalent to IAO &apos;source code module&apos; (IAO_0000096) on the same level as &apos;software&apos;? From the textual definition in IAO it seems fairly close. (JH)</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000341 -->
+    <!-- software method -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000341">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000341">
         <rdfs:label>software method</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000139"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000139"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000330"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000500"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000330"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000500"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000500"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000500"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000505"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000505"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A software method (also called subroutine, subprogram, procedure, method, function, or routine) is a programming language implementation of a plan specification which is capable of realizing some objective specification when part of a software application.</dc:description>
@@ -2388,19 +2561,19 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000342 -->
+    <!-- software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000342">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000342">
         <rdfs:label>software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000343"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000343"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_part"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000340"/>
-                            <rdf:Description rdf:about="&resource;CHEMINF_000341"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000340"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000341"/>
                         </owl:unionOf>
                     </owl:Class>
                 </owl:someValuesFrom>
@@ -2411,25 +2584,25 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000343 -->
+    <!-- software application -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000343">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000343">
         <rdfs:label>software application</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000139"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000139"/>
         <dc:description>A software application is a programming language implementation of a plan specification capable of realizing some objective specification.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000344 -->
+    <!-- logD calculated at pH 5.5 by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000344">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000344">
         <rdfs:label>logD calculated at pH 5.5 by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000322"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000322"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Octanol-water distribution coefficient calculated at pH 5.5 by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2437,15 +2610,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000345 -->
+    <!-- hydrogen bond acceptor count calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000345">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000345">
         <rdfs:label>hydrogen bond acceptor count calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000245"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000245"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Hydrogen bond acceptor count that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2453,15 +2626,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000346 -->
+    <!-- hydrogen bond donor count calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000346">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000346">
         <rdfs:label>hydrogen bond donor count calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000244"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000244"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Hydrogen bond donor count that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2469,15 +2642,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000347 -->
+    <!-- Boiling point at 760 mmHg pressure calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000347">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000347">
         <rdfs:label>Boiling point at 760 mmHg pressure calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000257"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000257"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>The boiling point of a substance at 760 mmHg pressure that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2485,25 +2658,25 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000348 -->
+    <!-- number of freely rotating bonds calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000348">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000348">
         <rdfs:label>number of freely rotating bonds calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000254"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000254"/>
         <dc:description>Number of freely rotating bonds that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000349 -->
+    <!-- polar surface area calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000349">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000349">
         <rdfs:label>polar surface area calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000307"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000307"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Polar surface area that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2511,35 +2684,35 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000350 -->
+    <!-- molecular weight of the corresponding free base -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000350">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000350">
         <rdfs:label>molecular weight of the corresponding free base</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000216"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000216"/>
         <dc:description>The molecular weight for the free base chemical structure matching this chemical structure.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000351 -->
+    <!-- molar refractivity calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000351">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000351">
         <rdfs:label>molar refractivity calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000001"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000001"/>
         <dc:description>Molar refractivity that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000352 -->
+    <!-- index of refraction calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000352">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000352">
         <rdfs:label>index of refraction calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000253"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000253"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Index of refraction that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2547,15 +2720,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000353 -->
+    <!-- polarizability calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000353">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000353">
         <rdfs:label>polarizability calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000089"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000089"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Polarizability that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2563,23 +2736,44 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000354 -->
+    <!-- execution of ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000354">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000354">
         <rdfs:label>execution of ACD/Labs PhysChem software library version 12.01</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&ro;has_participant"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                     <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&ro;part_of"/>
-                                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000142"/>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000142"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000142"/>
                                     </owl:Restriction>
                                 </owl:intersectionOf>
                             </owl:Class>
@@ -2593,23 +2787,44 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000355 -->
+    <!-- execution of Pipeline Pilot -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000355">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000355">
         <rdfs:label>execution of Pipeline Pilot</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&ro;has_participant"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                     <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&ro;part_of"/>
-                                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000328"/>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000328"/>
                                     </owl:Restriction>
                                 </owl:intersectionOf>
                             </owl:Class>
@@ -2623,34 +2838,55 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000356 -->
+    <!-- GGA Indigo -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000356">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000356">
         <rdfs:label>GGA Indigo</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000356"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000356"/>
         <obo:IAO_0000115>http://ggasoftware.com/opensource/indigo</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000357 -->
+    <!-- execution of GGA Indigo -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000357">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000357">
         <rdfs:label>execution of GGA Indigo</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&ro;has_participant"/>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                     <owl:Restriction>
-                                        <owl:onProperty rdf:resource="&ro;part_of"/>
-                                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000356"/>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000356"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000356"/>
                                     </owl:Restriction>
                                 </owl:intersectionOf>
                             </owl:Class>
@@ -2664,15 +2900,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000358 -->
+    <!-- molar volume calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000358">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000358">
         <rdfs:label>molar volume calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000415"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000415"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Molar volume that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2680,15 +2916,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000359 -->
+    <!-- density calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000359">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000359">
         <rdfs:label>density calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000416"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000416"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Density that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2696,15 +2932,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000360 -->
+    <!-- flash point calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000360">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000360">
         <rdfs:label>flash point calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000417"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000417"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Flash point that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2712,15 +2948,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000361 -->
+    <!-- enthalpy of vaporization calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000361">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000361">
         <rdfs:label>enthalpy of vaporization calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000418"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000418"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Enthalpy of vaporization that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2728,15 +2964,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000362 -->
+    <!-- vapour pressure calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000362">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000362">
         <rdfs:label>vapour pressure calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000419"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000419"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Vapour pressure that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2744,15 +2980,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000363 -->
+    <!-- organic carbon adsorption coefficient at pH 5.5 calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000363">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000363">
         <rdfs:label>organic carbon adsorption coefficient at pH 5.5 calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000413"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000413"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Organic carbon adsorption coefficient at pH 5.5 that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2760,15 +2996,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000364 -->
+    <!-- organic carbon adsorption coefficient at pH 7.4 calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000364">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000364">
         <rdfs:label>organic carbon adsorption coefficient at pH 7.4 calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000413"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000413"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Organic carbon adsorption coefficient at pH 7.4 that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2776,15 +3012,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000365 -->
+    <!-- bioconcentration factor at pH 5.5 calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000365">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000365">
         <rdfs:label>bioconcentration factor at pH 5.5 calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000414"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000414"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Bioconcentration factor at pH 7.4 that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2792,15 +3028,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000366 -->
+    <!-- bioconcentration factor at pH 7.4 calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000366">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000366">
         <rdfs:label>bioconcentration factor at pH 7.4 calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000414"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000414"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Bioconcentration factor at pH 7.4 that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2808,15 +3044,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000367 -->
+    <!-- number of rule of five violations calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000367">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000367">
         <rdfs:label>number of rule of five violations calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000312"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Number of rule of five violations for a chemical structure that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2824,15 +3060,15 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000368 -->
+    <!-- surface tension calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000368">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000368">
         <rdfs:label>surface tension calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000420"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000420"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Surface tension, in dyne per centimetre, that has been calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -2840,27 +3076,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000369 -->
+    <!-- covalent unit count generated by pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000369">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000369">
         <rdfs:label xml:lang="en">covalent unit count generated by pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000280"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000280"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2875,27 +3137,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000370 -->
+    <!-- defined atom stereocenter count generated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000370">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000370">
         <rdfs:label xml:lang="en">defined atom stereocenter count generated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000206"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000206"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2910,27 +3198,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000371 -->
+    <!-- defined bond stereocenter count generated by pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000371">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000371">
         <rdfs:label xml:lang="en">defined bond stereocenter count generated by pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000214"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000214"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2945,27 +3259,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000372 -->
+    <!-- isotope atom count generated by pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000372">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000372">
         <rdfs:label xml:lang="en">isotope atom count generated by pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000301"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000301"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -2980,27 +3320,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000373 -->
+    <!-- heavy atom count generated by pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000373">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000373">
         <rdfs:label xml:lang="en">heavy atom count generated by pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000300"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000300"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3015,27 +3381,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000374 -->
+    <!-- undefined atom stereocenter count generated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000374">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000374">
         <rdfs:label xml:lang="en">undefined atom stereocenter count generated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000212"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000212"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3050,27 +3442,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000375 -->
+    <!-- undefined bond stereocenter count generated by the pubchem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000375">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000375">
         <rdfs:label xml:lang="en">undefined bond stereocenter count generated by the pubchem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000215"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000215"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000333"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000333"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3085,27 +3503,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000376 -->
+    <!-- canonical smiles generated by OEChem -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000376">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000376">
         <rdfs:label xml:lang="en">canonical smiles generated by OEChem</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000007"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000007"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000378"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000378"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000378"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3120,46 +3564,72 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000377 -->
+    <!-- OEChem software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000377">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000377">
         <rdfs:label xml:lang="en">OEChem software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://www.eyesopen.com/oechem-tk</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000378 -->
+    <!-- OEChem software library version 1.9.0 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000378">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000378">
         <rdfs:label xml:lang="en">OEChem software library version 1.9.0</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000377"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000377"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000379 -->
+    <!-- isomeric SMILES generated by OEChem -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000379">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000379">
         <rdfs:label xml:lang="en">isomeric SMILES generated by OEChem</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000032"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000032"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000378"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000378"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000378"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3174,48 +3644,74 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000380 -->
+    <!-- cycle count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000380">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000380">
         <rdfs:label xml:lang="en">cycle count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <obo:IAO_0000115>A descriptor that specifies the integer count of cycles in a given molecular entity.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000381 -->
+    <!-- aromatic cycle count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000381">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000381">
         <rdfs:label xml:lang="en">aromatic cycle count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000380"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000380"/>
         <obo:IAO_0000115>A descriptor that specifies the integer count of aromatic cycles in a given molecular entity.</obo:IAO_0000115>
         <obo:IAO_0000118>aromatic rings</obo:IAO_0000118>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000382 -->
+    <!-- IUPAC Name generated by LexiChem -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000382">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000382">
         <rdfs:label xml:lang="en">IUPAC Name generated by LexiChem</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000107"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000107"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000384"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000384"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000384"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3230,65 +3726,91 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000383 -->
+    <!-- LexiChem -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000383">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000383">
         <rdfs:label xml:lang="en">LexiChem</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://www.eyesopen.com/news/lexichem-v210-released</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000384 -->
+    <!-- LexiChem version 2.2.0 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000384">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000384">
         <rdfs:label xml:lang="en">LexiChem version 2.2.0</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000383"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000383"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000385 -->
+    <!-- Cactvs software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000385">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000385">
         <rdfs:label xml:lang="en">Cactvs software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://www2.ccc.uni-erlangen.de/software/cactvs/tools.html</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000386 -->
+    <!-- Cactvs software library version 3.408 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000386">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000386">
         <rdfs:label xml:lang="en">Cactvs software library version 3.408</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000385"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000385"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000387 -->
+    <!-- hydrogen bond donor count calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000387">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000387">
         <rdfs:label xml:lang="en">hydrogen bond donor count calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000244"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000244"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3303,27 +3825,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000388 -->
+    <!-- hydrogen bond acceptor count calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000388">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000388">
         <rdfs:label xml:lang="en">hydrogen bond acceptor count calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000245"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000245"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3338,27 +3886,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000389 -->
+    <!-- rotatable bond count calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000389">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000389">
         <rdfs:label xml:lang="en">rotatable bond count calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000254"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000254"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3373,27 +3947,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000390 -->
+    <!-- structure complexity calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000390">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000390">
         <rdfs:label xml:lang="en">structure complexity calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000219"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000219"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3408,27 +4008,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000391 -->
+    <!-- tautomer count calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000391">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000391">
         <rdfs:label xml:lang="en">tautomer count calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000202"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000202"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3443,27 +4069,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000392 -->
+    <!-- TPSA calculated by cactvs -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000392">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000392">
         <rdfs:label xml:lang="en">TPSA calculated by cactvs</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000174"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000174"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000386"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000386"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3478,46 +4130,72 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000393 -->
+    <!-- XLogP3 software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000393">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000393">
         <rdfs:label xml:lang="en">XLogP3 software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://www.sioc-ccbg.ac.cn/skins/ccbgwebsite/software/xlogp3/manual/XLOGP3_Manual.pdf</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000394 -->
+    <!-- XLogP3 software library version 3.0 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000394">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000394">
         <rdfs:label xml:lang="en">XLogP3 software library version 3.0</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000393"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000393"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000395 -->
+    <!-- xlogp3 calculated by the xlogp3 software -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000395">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000395">
         <rdfs:label xml:lang="en">xlogp3 calculated by the xlogp3 software</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000186"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000186"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000394"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000394"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000394"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3532,27 +4210,53 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000396 -->
+    <!-- InChI calculated by library version 1.0.4 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000396">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000396">
         <rdfs:label xml:lang="en">InChI calculated by library version 1.0.4</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000113"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000113"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000398"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000398"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000398"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3567,46 +4271,72 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000397 -->
+    <!-- InChI software library -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000397">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000397">
         <rdfs:label xml:lang="en">InChI software library</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000342"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
         <obo:IAO_0000115>http://old.iupac.org/inchi/download/index.html</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000398 -->
+    <!-- InChI software library version 1.0.4 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000398">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000398">
         <rdfs:label xml:lang="en">InChI software library version 1.0.4</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000397"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000397"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000399 -->
+    <!-- InChIKey generated by software version 1.0.4 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000399">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000399">
         <rdfs:label xml:lang="en">InChIKey generated by software version 1.0.4</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000059"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000059"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
                 <owl:someValuesFrom>
                     <owl:Class>
                         <owl:intersectionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&resource;CHEMINF_000138"/>
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
                             <owl:Restriction>
-                                <owl:onProperty rdf:resource="&ro;has_participant"/>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                                             <owl:Restriction>
-                                                <owl:onProperty rdf:resource="&ro;part_of"/>
-                                                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000398"/>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000398"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000398"/>
                                             </owl:Restriction>
                                         </owl:intersectionOf>
                                     </owl:Class>
@@ -3621,174 +4351,168 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000400 -->
+    <!-- chemical graph -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000400"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000400"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000404 -->
+    <!-- chemical disposition -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000404">
-        <rdfs:subClassOf rdf:resource="&snap;Disposition"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000404">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000405 -->
+    <!-- ChemSpider identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000405">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000405">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000406 -->
+    <!-- DrugBank identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000406">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000406">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000407 -->
+    <!-- ChEBI identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000407">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000407">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000408 -->
+    <!-- HMDB identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000408">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000408">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000409 -->
+    <!-- KEGG identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000409">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000409">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000410 -->
+    <!-- Wikipedia identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000410">
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
-    </rdf:Description>
-    
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000567 -->
-
-    <rdf:Description rdf:about="&resource;CHEMINF_000567">
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
-    </rdf:Description>
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000411 -->
-
-    <rdf:Description rdf:about="&resource;CHEMINF_000411">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000412 -->
+    <!-- Reactome identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000412">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000411">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000414 -->
+    <!-- ChEMBL identifier -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000414">
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000412">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
+    </rdf:Description>
+    
+
+
+    <!-- bioconcentration factor descriptor -->
+
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000414">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000416 -->
+    <!-- density descriptor -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000416">
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000416">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000417 -->
+    <!-- flash point descriptor -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000417">
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000417">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000429 -->
+    <!-- OEChem software library version 1.7.6 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000429">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000429">
         <rdfs:label xml:lang="en">OEChem software library version 1.7.6</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000377"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000377"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000430 -->
+    <!-- structural alert count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000430">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000430">
         <rdfs:label xml:lang="en">structural alert count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000209"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000209"/>
         <obo:IAO_0000115>The number of structural alerts, that is, unwanted features as defined according to the procedure followed in Brenk et al., 2008. 
 Brenk R, et al. Lessons learnt from assembling screening libraries for drug discovery for neglected diseases. Chem Med Chem. 2008;3:435–444. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000431 -->
+    <!-- weighted quantitative estimate of drug-likeness -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000431">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000431">
         <rdfs:label xml:lang="en">weighted quantitative estimate of drug-likeness</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
-        <obo:IAO_0000118>QED weighted</obo:IAO_0000118>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>A descriptor which gives a quantitative estimate of drug likeness according to the procedure outlined in Bickerton et al., 2012. 
 
 http://www.ncbi.nlm.nih.gov/pubmed/22270643
 Nat Chem. 2012 Jan 24;4(2):90-8. doi: 10.1038/nchem.1243.
 Quantifying the chemical beauty of drugs.
 Bickerton GR, Paolini GV, Besnard J, Muresan S, Hopkins AL.</obo:IAO_0000115>
+        <obo:IAO_0000118>QED weighted</obo:IAO_0000118>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000432 -->
+    <!-- freezing point descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000432">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000432">
         <rdfs:label xml:lang="en">freezing point descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor that indicates the temperature at which a chemical substance undergoes a state transition from gas or liquid to solid, under standard conditions.</dc:description>
@@ -3796,15 +4520,15 @@ Bickerton GR, Paolini GV, Besnard J, Muresan S, Hopkins AL.</obo:IAO_0000115>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000433 -->
+    <!-- Henry&apos;s Law constant -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000433">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000433">
         <rdfs:label xml:lang="en">Henry&apos;s Law constant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Henry&apos;s law, formulated by William Henry in 1803, states &quot;At a constant temperature, the amount of a given gas that dissolves in a given type and volume of liquid is directly proportional to the partial pressure of that gas in equilibrium with that liquid.&quot; Henry&apos;s law can be put into mathematical terms (at constant temperature) as
@@ -3814,15 +4538,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000434 -->
+    <!-- atmospheric OH rate constant -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000434">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000434">
         <rdfs:label xml:lang="en">atmospheric OH rate constant</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the rate constant of a reaction of a chemical entity with OH. This is used to describe the atmospheric behaviour (i.e. stability) of the entity. </dc:description>
@@ -3830,15 +4554,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000435 -->
+    <!-- upper explosive limit descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000435">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000435">
         <rdfs:label xml:lang="en">upper explosive limit descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the upper explosive limit of the entity in air as a percentage by volume at room temperature. </dc:description>
@@ -3846,15 +4570,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000436 -->
+    <!-- lower explosive limit descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000436">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000436">
         <rdfs:label xml:lang="en">lower explosive limit descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the lower explosive limit in air as a percentage by volume at room temperature</dc:description>
@@ -3862,15 +4586,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000437 -->
+    <!-- minimum explosive concentration descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000437">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000437">
         <rdfs:label xml:lang="en">minimum explosive concentration descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the minimum explosive concentration. </dc:description>
@@ -3878,15 +4602,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000438 -->
+    <!-- specific gravity descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000438">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000438">
         <rdfs:label xml:lang="en">specific gravity descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor of the ratio of the density of chemical substance to the density of a reference substance. The reference substance is usually water for liquids or air for gases. </dc:description>
@@ -3894,15 +4618,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000439 -->
+    <!-- relative density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000439">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000439">
         <rdfs:label xml:lang="en">relative density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor of the relative density of gases referenced to air as 1, which indicates how many times a gas is heavier than air at the same temperature. </dc:description>
@@ -3910,15 +4634,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000440 -->
+    <!-- vapor density descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000440">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000440">
         <rdfs:label xml:lang="en">vapor density descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A descriptor of the density of a vapour in relation in that of hydrogen, defined as the mass of a certain volume of the given substance divided by the mass of the same volume of hydrogen. </dc:description>
@@ -3926,15 +4650,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000441 -->
+    <!-- odor detection threshold descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000441">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000441">
         <rdfs:label xml:lang="en">odor detection threshold descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the lowest concentration of an odorant chemical entity that is perceivable by the human sense of smell. </dc:description>
@@ -3942,15 +4666,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000442 -->
+    <!-- pH descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000442">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000442">
         <rdfs:label xml:lang="en">pH descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor which gives a measure of the acidity or basicity of an aqueous solution, defined as the decimal logarithm of the reciprocal of the hydrogen ion activity in a solution. </dc:description>
@@ -3958,15 +4682,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000443 -->
+    <!-- evaporation rate descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000443">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000443">
         <rdfs:label xml:lang="en">evaporation rate descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor of the rate of evaporation of a liquid under standard conditions. </dc:description>
@@ -3974,32 +4698,32 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000444 -->
+    <!-- autoignition temperature descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000444">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000444">
         <rdfs:label xml:lang="en">autoignition temperature descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <dc:description>A physical descriptor of the lowest temperature at a substance will spontaneously ignite in a normal atmosphere without an external source of ignition. </dc:description>
         <obo:IAO_0000118>kindling point</obo:IAO_0000118>
+        <dc:description>A physical descriptor of the lowest temperature at a substance will spontaneously ignite in a normal atmosphere without an external source of ignition. </dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000445 -->
+    <!-- soil half-life descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000445">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000445">
         <rdfs:label xml:lang="en">soil half-life descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000266"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A physical descriptor for the time it takes for half of a portion of substance of a given type to decompose in soil under standard conditions. </dc:description>
@@ -4007,67 +4731,67 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000446 -->
+    <!-- CAS registry number -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000446">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000446">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000447 -->
+    <!-- European Community number -->
 
-    <rdf:Description rdf:about="&resource;CHEMINF_000447">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000447">
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
     </rdf:Description>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000448 -->
+    <!-- metal atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000448">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000448">
         <rdfs:label xml:lang="en">metal atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000263"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
         <obo:IAO_0000115>A descriptor that specifies the integer count of metal atoms in a given chemical entity. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000449 -->
+    <!-- oxygen atom count -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000449">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000449">
         <rdfs:label xml:lang="en">oxygen atom count</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000263"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000263"/>
         <obo:IAO_0000115>A descriptor that specifies the integer count of oxygen atoms in a given chemical entity. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000450 -->
+    <!-- algorithm to calculate a molecular descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000450"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000450"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000451 -->
+    <!-- software module to calculate a molecular descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000451">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000451">
         <rdfs:label>software module to calculate a molecular descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000103"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
                     <owl:Restriction>
-                        <owl:onProperty rdf:resource="&resource;CHEMINF_000331"/>
-                        <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000065"/>
+                        <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000331"/>
+                        <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000065"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000450"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000450"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>A software module to calculate a molecular descriptor is software module that implements an algorithm which calculates a descriptor value for a molecular entity.</dc:description>
@@ -4075,76 +4799,76 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000464 -->
+    <!-- chemical database identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000464">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000464">
         <rdfs:label>chemical database identifier</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000061"/>
-        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000061"/>
         <obo:IAO_0000115>An identifying descriptor which is used within a particular database system to identify a chemical system.</obo:IAO_0000115>
-    </owl:Class>
-    
-
-
-    <!-- http://semanticscience.org/resource/CHEMINF_000465 -->
-
-    <owl:Class rdf:about="&resource;CHEMINF_000465">
-        <rdfs:label>ChemSpider validated synonym</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000044"/>
         <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
-        <obo:IAO_0000115>A preferred name in ChemSpider by virtue of having been validated by a curator.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000466 -->
+    <!-- ChemSpider validated synonym -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000466">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000465">
+        <rdfs:label>ChemSpider validated synonym</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000044"/>
+        <obo:IAO_0000115>A preferred name in ChemSpider by virtue of having been validated by a curator.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
+    </owl:Class>
+    
+
+
+    <!-- ChemSpider unvalidated synonym -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000466">
         <rdfs:label>ChemSpider unvalidated synonym</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <obo:IAO_0000115>A molecular entity name in the ChemSpider database which has not been validated by a curator.</obo:IAO_0000115>
         <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000467 -->
+    <!-- validated chemical database identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000467">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000467">
         <rdfs:label>validated chemical database identifier</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&obo;OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000469"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000469"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
         <obo:IAO_0000115>A chemical database identifier which has been validated by a curator.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000468 -->
+    <!-- curator role -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000468">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000468">
         <rdfs:label>curator role</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&snap;Role"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
         <obo:IAO_0000115>A role inhering in a person which is realized when they perform a curation task.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000469 -->
+    <!-- CRID validation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000469">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000469">
         <rdfs:label>CRID validation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000577"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A planned process in which a person bearing a curator role confirms an association between a CRID and an information content entity.</obo:IAO_0000115>
@@ -4153,15 +4877,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000470 -->
+    <!-- chemical name devalidation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000470">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000470">
         <rdfs:label>chemical name devalidation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000043"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A planned process in which a person bearing a curator role marks an association between a chemical name and an information content entity as unconfirmed.</obo:IAO_0000115>
@@ -4170,15 +4894,15 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000471 -->
+    <!-- CRID registry curation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000471">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000471">
         <rdfs:label>CRID registry curation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;OBI_0000011"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000579"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000579"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A planned process in which a person bearing a curator role modifies a CRID registry.</obo:IAO_0000115>
@@ -4187,67 +4911,67 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000472 -->
+    <!-- chemical name validation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000472">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000472">
         <rdfs:label>chemical name validation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000043"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
         <obo:IAO_0000115>A planned process in which a person bearing a curator role confirms an association between a chemical name and an information content entity.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000473 -->
+    <!-- chemical name deprecation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000473">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000473">
         <rdfs:label>chemical name deprecation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000043"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
         <obo:IAO_0000115>A planned process in which a person bearing a curator role deprecates an association between a chemical name and an information content entity.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000474 -->
+    <!-- CRID deprecation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000474">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000474">
         <rdfs:label>CRID deprecation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:comment>This can be done automatically; it does not need a person bearing a curator role.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000577"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A planned process in which an association between a CRID and an information content entity is deprecated.</obo:IAO_0000115>
-        <rdfs:comment>This can be done automatically; it does not need a person bearing a curator role.</rdfs:comment>
         <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000475 -->
+    <!-- CRID devalidation -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000475">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000475">
         <rdfs:label>CRID devalidation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000471"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000471"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ro;has_participant"/>
-                <owl:someValuesFrom rdf:resource="&obo;IAO_0000577"/>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A planned process in which an association between a CRID and an information content entity is marked as unconfirmed.</obo:IAO_0000115>
@@ -4256,68 +4980,68 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000476 -->
+    <!-- ChemSpider title -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000476">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000476">
         <rdfs:label>ChemSpider title</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000465"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000465"/>
         <obo:IAO_0000115>A ChemSpider validated synonym that has been identified as a title by the ChemSpider software.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000484 -->
+    <!-- average molecular weight descriptor calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000484">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000484">
         <rdfs:label>average molecular weight descriptor calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000216"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000216"/>
         <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000485 -->
+    <!-- monoisotopic molecular weight descriptor calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000485">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000485">
         <rdfs:label>monoisotopic molecular weight descriptor calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000218"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000218"/>
         <obo:IAO_0000117>Person: Colin Batchelor</obo:IAO_0000117>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000487 -->
+    <!-- energy band gap -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000487">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000487">
         <rdfs:label xml:lang="en">energy band gap</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000016"/>
-        <obo:IAO_0000118>energy gap</obo:IAO_0000118>
-        <obo:IAO_0000118>band gap</obo:IAO_0000118>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000016"/>
         <obo:IAO_0000115>A descriptor that describes the energy range in a solid where no electron states can exist. In graphs of the electron band structure of solids, the band gap generally refers to the energy difference (in electron volts) between the top of the valence band and the bottom of the conduction band in insulators and semiconductors. [http://en.wikipedia.org/wiki/Band_gap]</obo:IAO_0000115>
+        <obo:IAO_0000118>band gap</obo:IAO_0000118>
+        <obo:IAO_0000118>energy gap</obo:IAO_0000118>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000488 -->
+    <!-- metal element mass descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000488">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000488">
         <rdfs:label xml:lang="en">metal element mass descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000083"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000083"/>
         <obo:IAO_0000115>A descriptor describing the mass of the metal element component of a composite substance. </obo:IAO_0000115>
         <obo:IAO_0000118>metal element mass</obo:IAO_0000118>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000490 -->
+    <!-- molecular formula calculated by ACD/Labs PhysChem software library version 12.01 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000490">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000490">
         <rdfs:label>molecular formula calculated by ACD/Labs PhysChem software library version 12.01</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000042"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000042"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&ontologies;is_output_of"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000354"/>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000354"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <dc:description>Molecular formula for a chemical structure as calculated by ACD/Labs PhysChem software library version 12.01.</dc:description>
@@ -4325,73 +5049,73 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000496 -->
+    <!-- partition coefficient -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000496">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000496">
         <rdfs:label xml:lang="en">partition coefficient</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000025"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000025"/>
         <obo:IAO_0000115>The ratio of a dissolved substance in a two-phase system, giving a measure of the difference in solubility of the substance in the two phases.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000500 -->
+    <!-- parameter data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000500">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000500">
         <rdfs:label>parameter data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
         <obo:IAO_0000115>A parameter data item is a data item that plays the role of a parameter to a software method. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000501 -->
+    <!-- numeric data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000501">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000501">
         <rdfs:label>numeric data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000509"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000509"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
                 <owl:someValuesFrom>
                     <rdfs:Datatype>
                         <owl:unionOf rdf:parseType="Collection">
-                            <rdf:Description rdf:about="&xsd;decimal"/>
-                            <rdf:Description rdf:about="&xsd;float"/>
-                            <rdf:Description rdf:about="&xsd;integer"/>
-                            <rdf:Description rdf:about="&xsd;long"/>
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#decimal"/>
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#float"/>
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#integer"/>
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#long"/>
                         </owl:unionOf>
                     </rdfs:Datatype>
                 </owl:someValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <owl:disjointWith rdf:resource="&resource;CHEMINF_000502"/>
+        <owl:disjointWith rdf:resource="http://semanticscience.org/resource/CHEMINF_000502"/>
         <obo:IAO_0000115>A numeric data item is a data item which has a value which is numeric. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000502 -->
+    <!-- textual data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000502">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000502">
         <rdfs:label>textual data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000027"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000047"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000510"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000047"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000510"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000012"/>
-                <owl:someValuesFrom rdf:resource="&xsd;string"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>A textual data item is a data item which has a value that has at least some non-numeric characters included in it. </obo:IAO_0000115>
@@ -4399,153 +5123,153 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000503 -->
+    <!-- numeric parameter -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000503">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000503">
         <rdfs:label>numeric parameter</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000500"/>
-                    <rdf:Description rdf:about="&resource;CHEMINF_000501"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000500"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000501"/>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000500"/>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000501"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000500"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000501"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000504 -->
+    <!-- textual parameter -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000504">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000504">
         <rdfs:label>textual parameter</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000500"/>
-                    <rdf:Description rdf:about="&resource;CHEMINF_000502"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000500"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000502"/>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000500"/>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000502"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000500"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000502"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000509 -->
+    <!-- numeric data format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000509">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000509">
         <rdfs:label>numeric data format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000098"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000098"/>
         <obo:IAO_0000115>A numeric data format specification is a data format specification for data items which are numeric, that is, they contain only numeric values.  </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000510 -->
+    <!-- textual data format specification -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000510">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000510">
         <rdfs:label>textual data format specification</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000098"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000098"/>
         <obo:IAO_0000115>A textual data format specification is a specification of the format of data items which are textual, that is, they consist of character data. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000511 -->
+    <!-- numeric chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000511">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000511">
         <rdfs:label>numeric chemical descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000123"/>
-                    <rdf:Description rdf:about="&resource;CHEMINF_000501"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000123"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000501"/>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000512 -->
+    <!-- textual chemical descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000512">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000512">
         <rdfs:label>textual chemical descriptor</rdfs:label>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&resource;CHEMINF_000123"/>
-                    <rdf:Description rdf:about="&resource;CHEMINF_000502"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000123"/>
+                    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000502"/>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000123"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000123"/>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000513 -->
+    <!-- chemical substance descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000513"/>
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000513"/>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000515 -->
+    <!-- specific surface area -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000515">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000515">
         <rdfs:label xml:lang="en">specific surface area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000101"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000101"/>
         <obo:IAO_0000115>A property of solids which is the total surface area of a material per unit of mass, solid or bulk volume, or cross-sectional area. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000516 -->
+    <!-- group of an atom -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000516">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000516">
         <rdfs:label xml:lang="en">group of an atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>Descriptor that returns the group in the periodic table of a given atom.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000550 -->
+    <!-- ChEBI name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000550">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000550">
         <rdfs:label>ChEBI name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000044"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000044"/>
         <obo:IAO_0000115>A ChEBI name is a preferred name annotated by the ChEBI database.  The ChEBI name has the additional feature that it is unique within the ChEBI dataset. </obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000552 -->
+    <!-- algorithm to interpret a connection table -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000552">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000552">
         <rdfs:label xml:lang="en">algorithm to interpret a connection table</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&obo;IAO_0000064"/>
-        <dc:description>An algorithm that specifies how to take a connection table and convert it into a representation of a molecule.</dc:description>
-        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
         <rdfs:comment>This may of course not be successful!</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000064"/>
+        <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
+        <dc:description>An algorithm that specifies how to take a connection table and convert it into a representation of a molecule.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000553 -->
+    <!-- structural standardization error -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000553">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000553">
         <rdfs:label xml:lang="en">structural standardization error</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000507"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000507"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000424"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000424"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000117>Colin Batchelor</obo:IAO_0000117>
@@ -4554,748 +5278,1181 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000554 -->
+    <!-- structural standardization warning -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000554">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000554">
         <rdfs:label xml:lang="en">structural standardization warning</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000506"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000506"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000423"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000423"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000555 -->
+    <!-- connection table interpretation warning -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000555">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000555">
         <rdfs:label xml:lang="en">connection table interpretation warning</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000506"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000506"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000552"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000552"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000556 -->
+    <!-- connection table interpretation error -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000556">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000556">
         <rdfs:label xml:lang="en">connection table interpretation error</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000507"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000507"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000552"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000552"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000557 -->
+    <!-- information data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000557">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000557">
         <rdfs:label xml:lang="en">information data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000505"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000505"/>
         <dc:description>A software message data item which is merely intended to convey information and not a warning or an error.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000558 -->
+    <!-- connection table interpretation information data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000558">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000558">
         <rdfs:label xml:lang="en">connection table interpretation information data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000557"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000557"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000552"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000552"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000559 -->
+    <!-- structural standardization information data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000559">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000559">
         <rdfs:label xml:lang="en">structural standardization information data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000557"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000557"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000424"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000424"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000560 -->
+    <!-- structural validation information data item -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000560">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000560">
         <rdfs:label xml:lang="en">structural validation information data item</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000557"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000557"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&resource;CHEMINF_000606"/>
-                <owl:someValuesFrom rdf:resource="&resource;CHEMINF_000423"/>
+                <owl:onProperty rdf:resource="http://semanticscience.org/resource/CHEMINF_000606"/>
+                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000423"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000561 -->
+    <!-- drug trade name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000561">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000561">
         <rdfs:label>drug trade name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <obo:IAO_0000115>Trade name of a drug compound.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000562 -->
+    <!-- International Non-proprietary Name -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000562">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000562">
         <rdfs:label>International Non-proprietary Name</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000043"/>
-        <short_name>INN</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000043"/>
         <obo:IAO_0000115>International Non-proprietary Name, defined by the WHO.</obo:IAO_0000115>
+        <cheminf1:short_name>INN</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000563 -->
+    <!-- Unique Ingredient Identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000563">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000563">
         <rdfs:label>Unique Ingredient Identifier</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
         <dc:description>Identifier used by the USA Food and Drug Administration.</dc:description>
-        <short_name>UNII</short_name>
+        <cheminf1:short_name>UNII</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000564 -->
+    <!-- LipidMaps identifier -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000564">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000564">
         <rdfs:label>LipidMaps identifier</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
         <dc:description>Identifier used by the LipidMaps database, http://www.lipidmaps.org/.</dc:description>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000565 -->
+    <!-- National Service Center number -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000565">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000565">
         <rdfs:label>National Service Center number</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
         <dc:description>Identifier used by the Cancer Chemotherapy National Service Center.</dc:description>
-        <short_name>NSC number</short_name>
+        <cheminf1:short_name>NSC number</cheminf1:short_name>
     </owl:Class>
     
 
-    <!-- http://semanticscience.org/resource/CHEMINF_000566 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_000566">
+    <!-- RTECS identifier -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000566">
         <rdfs:label>RTECS identifier</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
-	<dc:description>Identifier used by the RTECS database (http://www.cdc.gov/niosh/rtecs/).</dc:description>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000464"/>
+        <dc:description>Identifier used by the RTECS database (http://www.cdc.gov/niosh/rtecs/).</dc:description>
     </owl:Class>
+    
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001500 -->
+    <!-- CHEMINF_000567 -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001500">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000567">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000577"/>
+    </owl:Class>
+    
+
+
+    <!-- RDKit software library -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000800">
+        <rdfs:label xml:lang="en">RDKit software library</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000342"/>
+        <obo:IAO_0000115>http://www.rdkit.org/</obo:IAO_0000115>
+    </owl:Class>
+    
+
+
+    <!-- RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000801">
+        <rdfs:label xml:lang="en">RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000800"/>
+        <obo:IAO_0000115>http://www.rdkit.org/</obo:IAO_0000115>
+    </owl:Class>
+    
+
+
+    <!-- number of rule of five violations calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000802">
+        <rdfs:label xml:lang="en">number of rule of five violations calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000312"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- hydrogen bond acceptor count calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000803">
+        <rdfs:label xml:lang="en">hydrogen bond acceptor count calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000245"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- hydrogen bond donor count calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000804">
+        <rdfs:label xml:lang="en">hydrogen bond donor count calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000244"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- logP descriptor calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000805">
+        <rdfs:label xml:lang="en">logP descriptor calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000251"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- molecular formula calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000806">
+        <rdfs:label xml:lang="en">molecular formula calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000042"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- average molecular weight calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000807">
+        <rdfs:label xml:lang="en">average molecular weight calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000216"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- total polar surface area calculated by RDKit software library version 2015_09_2 -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_000808">
+        <rdfs:label xml:lang="en">total polar surface area calculated by RDKit software library version 2015_09_2</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000307"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.semanticweb.org/ontologies/is_output_of"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000138"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000103"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                                                <owl:someValuesFrom rdf:resource="http://semanticscience.org/resource/CHEMINF_000801"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- BCUT -->
+
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001500">
         <rdfs:label xml:lang="en">BCUT</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <bibo:doi rdf:datatype="&xsd;string"> http://dx.doi.org/10.1021/ci980137x</bibo:doi>
-        <short_name>BCUT</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Eigenvalue based descriptor noted for its utility in chemical diversity.</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string"> http://dx.doi.org/10.1021/ci980137x</bibo:doi>
+        <cheminf1:short_name>BCUT</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001501 -->
+    <!-- bond partial pi charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001501">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001501">
         <rdfs:label xml:lang="en">bond partial pi charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <short_name>bondPartialPiCharge</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates bond-pi Partial charge of a bond by determining the difference the Partial Pi Charge on atoms A and B of a bond (based in Gasteiger Charge).</dc:description>
+        <cheminf1:short_name>bondPartialPiCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001502 -->
+    <!-- bond partial sigma charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001502">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001502">
         <rdfs:label xml:lang="en">bond partial sigma charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates bond-sigma Partial charge of a bond.</dc:description>
-        <short_name>bondPartialSigmaCharge</short_name>
+        <cheminf1:short_name>bondPartialSigmaCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001503 -->
+    <!-- bond partial total charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001503">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001503">
         <rdfs:label xml:lang="en">bond partial total charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates bond-total Partial charge of a bond.</dc:description>
-        <short_name>bondPartialTCharge</short_name>
+        <cheminf1:short_name>bondPartialTCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001504 -->
+    <!-- bond sigma electronegativity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001504">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001504">
         <rdfs:label xml:lang="en">bond sigma electronegativity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates of bond-Polarizability of a bond by determining the difference the Sigma electronegativity on atoms A and B of a bond.</dc:description>
-        <short_name>bondSigmaElectronegativity</short_name>
+        <cheminf1:short_name>bondSigmaElectronegativity</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001505 -->
+    <!-- bonds to Atom -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001505">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001505">
         <rdfs:label xml:lang="en">bonds to Atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <dc:description>Descriptor based on the number of bonds on the shortest path between two atoms (topological distance).</dc:description>
         <rdfs:comment>This is the shortest distance between a pair of atoms in a graph, defined as the number of edges in the shortest path between the atom pair in the molecular graph.</rdfs:comment>
-        <short_name>bondsToAtom</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Descriptor based on the number of bonds on the shortest path between two atoms (topological distance).</dc:description>
+        <cheminf1:short_name>bondsToAtom</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001506 -->
+    <!-- chi chain indices -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001506">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001506">
         <rdfs:label xml:lang="en">chi chain indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:comment>It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Evluates the simple and valence chi chain descriptors (Kier and Hall) of orders 3, 4, 5, 6 and 7. </dc:description>
-        <rdfs:comment>It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
-        <short_name>chiChain</short_name>
+        <cheminf1:short_name>chiChain</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001507 -->
+    <!-- chi cluster indices -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001507">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001507">
         <rdfs:label xml:lang="en">chi cluster indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
         <rdfs:comment> It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
-        <short_name>chiCluster</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Evluates the simple and valence chi cluster descriptors (Kier and Hall) of orders 3, 4,5 and 6.</dc:description>
+        <cheminf1:short_name>chiCluster</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001508 -->
+    <!-- chi path indices -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001508">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001508">
         <rdfs:label xml:lang="en">chi path indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>chiPath</short_name>
+        <rdfs:comment>It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Evaluates the Kier and Hall Chi path indices of orders 0,1,2,3,4,5,6 and 7.  </dc:description>
-        <rdfs:comment>It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
+        <cheminf1:short_name>chiPath</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001509 -->
+    <!-- chi path-cluster indices -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001509">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001509">
         <rdfs:label xml:lang="en">chi path-cluster indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <dc:description>Evaluates the Kier and Hall Chi path cluster indices of orders 4,5 and 6.</dc:description>
         <rdfs:comment>It utilizes the graph isomorphism code of the CDK to find fragments matching SMILES strings representing the fragments corresponding to each type of chain.</rdfs:comment>
-        <short_name>chiPathCluster</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Evaluates the Kier and Hall Chi path cluster indices of orders 4,5 and 6.</dc:description>
+        <cheminf1:short_name>chiPathCluster</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001510 -->
+    <!-- gravitational index -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001510">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001510">
         <rdfs:label xml:lang="en">gravitational index</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/jp953224q</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <dc:description>Descriptor characterizing the mass distribution of the molecule.</dc:description>
-        <short_name>gravitationalIndex</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/jp953224q</bibo:doi>
+        <cheminf1:short_name>gravitationalIndex</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001511 -->
+    <!-- gravitational index (square and cube roots) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001511">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001511">
         <rdfs:label xml:lang="en">gravitational index (square and cube roots)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_001510"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/ci980029a</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_001510"/>
         <dc:description>Descriptor characterizing the mass distribution of the molecule as the square or cube root of the gravitational index.</dc:description>
-        <short_name>gravitationalIndex_SquareAndCubeRoots</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/ci980029a</bibo:doi>
+        <cheminf1:short_name>gravitationalIndex_SquareAndCubeRoots</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001512 -->
+    <!-- acceptor field atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001512">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001512">
         <rdfs:label xml:lang="en">acceptor field atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Counts the number of acceptor field atoms for a carbonyl oxygen probe using force field based definition.</dc:description>
-        <short_name>hBondAcceptorsBoehmKlebe</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
+        <cheminf1:short_name>hBondAcceptorsBoehmKlebe</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001513 -->
+    <!-- hydrogen bond acceptors (Daylight) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001513">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001513">
         <rdfs:label xml:lang="en">hydrogen bond acceptors (Daylight)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
         <rdfs:comment>SMILES on-line tutorial, http://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html)</rdfs:comment>
-        <short_name>hBondacceptorsDaylight</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates the number of hydrogen bond acceptors (by Daylight).</dc:description>
+        <cheminf1:short_name>hBondacceptorsDaylight</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001514 -->
+    <!-- acceptors or donors field atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001514">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001514">
         <rdfs:label xml:lang="en">acceptors or donors field atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Counts the number of acceptor/donor field atoms for a carbonyl oxygen or amino hydrogen probe. </dc:description>
-        <short_name>hBondAcceptorsDonorsBoehmKlebe</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
+        <cheminf1:short_name>hBondAcceptorsDonorsBoehmKlebe</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001515 -->
+    <!-- donor field atoms (Boehm,Klebe) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001515">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001515">
         <rdfs:label xml:lang="en">donor field atoms (Boehm,Klebe)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
-        <short_name>hBondDonorsBoehmKlebe</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Counts the number of donor field atoms for an amino hydrogen probe.</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/jm011039x</bibo:doi>
+        <cheminf1:short_name>hBondDonorsBoehmKlebe</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001516 -->
+    <!-- hydrogen bond donors (Daylight) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001516">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001516">
         <rdfs:label xml:lang="en">hydrogen bond donors (Daylight)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <short_name>hBondDonorsDaylight</short_name>
         <rdfs:comment>SMILES on-line tutorial, http://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html)</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates the number of hydrogen bond donors (by Daylight).</dc:description>
+        <cheminf1:short_name>hBondDonorsDaylight</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001517 -->
+    <!-- proton belonging to an aromatic system -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001517">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001517">
         <rdfs:label xml:lang="en">proton belonging to an aromatic system</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
-        <short_name>isProtonInAromaticSystem</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>Descriptor returns 1 if the protons is directly bonded to an aromatic system, it returns 2 if the distance between aromatic system and proton is 2 bonds, and it return 0 for other positions.</dc:description>
+        <cheminf1:short_name>isProtonInAromaticSystem</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001518 -->
+    <!-- proton belonging to a pi-system -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001518">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001518">
         <rdfs:label xml:lang="en">proton belonging to a pi-system</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
-        <short_name>isProtonInConjugatedPiSystem</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>Descriptor returns true if the protons is directly bonded to a pi system.</dc:description>
+        <cheminf1:short_name>isProtonInConjugatedPiSystem</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001519 -->
+    <!-- Kier Hall SMARTS -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001519">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001519">
         <rdfs:label xml:lang="en">Kier Hall SMARTS</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.3390/91201004</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Counts the number of occurrences of the E-state fragments.</dc:description>
-        <short_name>kierHallSmarts</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.3390/91201004</bibo:doi>
+        <cheminf1:short_name>kierHallSmarts</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001520 -->
+    <!-- molecular distance edge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001520">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001520">
         <rdfs:label xml:lang="en">molecular distance edge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/ci970109z</bibo:doi>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Evaluate molecular distance edge descriptors for C, N and O.</dc:description>
-        <short_name>mde</short_name>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/ci970109z</bibo:doi>
+        <cheminf1:short_name>mde</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001521 -->
+    <!-- moments of inertia -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001521">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001521">
         <rdfs:label xml:lang="en">moments of inertia</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <dc:description>Descriptor that calculates the principal moments of inertia and ratios of the principal moments. Als calculates the radius of gyration.</dc:description>
-        <short_name>momentOfInertia</short_name>
+        <cheminf1:short_name>momentOfInertia</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001522 -->
+    <!-- partial total charge (MMFF94) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001522">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001522">
         <rdfs:label xml:lang="en">partial total charge (MMFF94)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <short_name>partialTChargeMMFF94</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates total partial charges of an heavy atom.</dc:description>
+        <cheminf1:short_name>partialTChargeMMFF94</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001523 -->
+    <!-- period of an atom -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001523">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001523">
         <rdfs:label xml:lang="en">period of an atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
-        <short_name>period</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>Descriptor that returns the period in the periodic table of an atom belonging to an atom container.</dc:description>
+        <cheminf1:short_name>period</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001524 -->
+    <!-- pi-contact of two atoms -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001524">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001524">
         <rdfs:label xml:lang="en">pi-contact of two atoms</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000136"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000136"/>
         <dc:description>Descriptor that check if two atoms have pi-contact (this is true when there is one and the same conjugated pi-system which contains both atoms, or directly linked neighboors of the atoms).</dc:description>
-        <short_name>piContact</short_name>
+        <cheminf1:short_name>piContact</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001525 -->
+    <!-- proton total partial charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001525">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001525">
         <rdfs:label xml:lang="en">proton total partial charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <short_name>protonPartialCharge</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates partial charges of an heavy atom and its protons based on Gasteiger Marsili (PEOE).</dc:description>
+        <cheminf1:short_name>protonPartialCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001526 -->
+    <!-- RDF proton descriptor -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001526">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001526">
         <rdfs:label xml:lang="en">RDF proton descriptor</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1021/ac010737m</bibo:doi>
-        <dc:description>Calculation of RDF proton descriptor.</dc:description>
-        <short_name>rdfProtonCalculatedValues</short_name>
         <rdfs:comment>This is a mixed descriptor: topological, geometrical and electronic descriptor.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Calculation of RDF proton descriptor.</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1021/ac010737m</bibo:doi>
+        <cheminf1:short_name>rdfProtonCalculatedValues</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001527 -->
+    <!-- TAE RECON descriptors for amino acid sequences -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001527">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001527">
         <rdfs:label xml:lang="en">TAE RECON descriptors for amino acid sequences</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1016/0097-8485(94)00052-G</bibo:doi>
-        <short_name>taeAminoAcid</short_name>
-        <dc:description>Descriptors are derived from pre-calculated quantum mechanical parameters by using the paramaters for amino acids and evaluating a set of 147 descriptors for peptide sequences.</dc:description>
         <rdfs:comment>{@cdk.cite BREN1995} {@cdk.cite BREN1997} {@cdk.cite WHITE2003}</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
+        <dc:description>Descriptors are derived from pre-calculated quantum mechanical parameters by using the paramaters for amino acids and evaluating a set of 147 descriptors for peptide sequences.</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1016/0097-8485(94)00052-G</bibo:doi>
+        <cheminf1:short_name>taeAminoAcid</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001528 -->
+    <!-- weighted path -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001528">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001528">
         <rdfs:label xml:lang="en">weighted path</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>weightedPath</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>The weighted path (molecular ID) descriptors were described by Randic and they characterize molecular branching.</dc:description>
+        <cheminf1:short_name>weightedPath</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001529 -->
+    <!-- WHIM -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001529">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001529">
         <rdfs:label xml:lang="en">WHIM</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
         <rdfs:comment>Todeschini, R. and Gramatica, P.. New 3D Molecular Descriptors: The WHIM theory and QAR Applications, Persepectives in Drug Discovery and Design. 1998, pp. 355-380. Mixed descriptors: molecular size, shape, symmetry, and atom distribution and density. Uses 3D coordinates, PCA and it calculates 10 descriptors.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Holistic descriptors described by Todeschini et al.</dc:description>
-        <short_name>WHIM</short_name>
+        <cheminf1:short_name>WHIM</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001530 -->
+    <!-- Moreau-Broto Autocorrelation (charge) descriptors -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001530">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001530">
         <rdfs:label xml:lang="en">Moreau-Broto Autocorrelation (charge) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
         <rdfs:comment>ATSc1 - ATSc5</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>The Moreau-Broto autocorrelation descriptors using partial charges.</dc:description>
-        <short_name>autoCorrelationCharge</short_name>
+        <cheminf1:short_name>autoCorrelationCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001531 -->
+    <!-- Moreau-Broto autocorrelation (mass) descriptors -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001531">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001531">
         <rdfs:label xml:lang="en">Moreau-Broto autocorrelation (mass) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <dc:description>The Moreau-Broto autocorrelation descriptors using atomic weight.</dc:description>
-        <short_name>autoCorrelationMass</short_name>
         <rdfs:comment>ATSm1 - ATSm5</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>The Moreau-Broto autocorrelation descriptors using atomic weight.</dc:description>
+        <cheminf1:short_name>autoCorrelationMass</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001532 -->
+    <!-- Moreau-Broto autocorrelation (polarizability) descriptors -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001532">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001532">
         <rdfs:label xml:lang="en">Moreau-Broto autocorrelation (polarizability) descriptors</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
         <rdfs:comment>ATSp1 - ATSp5</rdfs:comment>
-        <short_name>autoCorrelationPolarizability</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>The Moreau-Broto autocorrelation descriptors using polarizability.</dc:description>
+        <cheminf1:short_name>autoCorrelationPolarizability</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001533 -->
+    <!-- carbon types -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001533">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001533">
         <rdfs:label xml:lang="en">carbon types</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>carbonTypes</short_name>
-        <dc:description>Characterizes the carbon connectivity in terms of hybridization</dc:description>
         <rdfs:comment>C1SP1, C2SP1, C1SP2, C2SP2, C3SP2, C1SP3, C2SP3, C3SP3, C4SP3</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Characterizes the carbon connectivity in terms of hybridization</dc:description>
+        <cheminf1:short_name>carbonTypes</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001534 -->
+    <!-- carbon connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001534">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001534">
         <rdfs:label xml:lang="en">carbon connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>chi0C</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates the carbon connectivity index (order 0). </dc:description>
+        <cheminf1:short_name>chi0C</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001535 -->
+    <!-- valence connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001535">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001535">
         <rdfs:label xml:lang="en">valence connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates atomic valence connectivity index (order 0). </dc:description>
-        <short_name>chi0v</short_name>
+        <cheminf1:short_name>chi0v</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001536 -->
+    <!-- valence carbon connectivity index (order 0) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001536">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001536">
         <rdfs:label xml:lang="en">valence carbon connectivity index (order 0)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>chi0vC</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates carbon valence connectivity index (order 0).</dc:description>
+        <cheminf1:short_name>chi0vC</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001537 -->
+    <!-- carbon connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001537">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001537">
         <rdfs:label xml:lang="en">carbon connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>chi1C</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates carbon connectivity index (order 1). </dc:description>
+        <cheminf1:short_name>chi1C</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001538 -->
+    <!-- valence connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001538">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001538">
         <rdfs:label xml:lang="en">valence connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <short_name>chi1v</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates atomic valence connectivity index (order 1). </dc:description>
+        <cheminf1:short_name>chi1v</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001539 -->
+    <!-- valence carbon connectivity index (order 1) -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001539">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001539">
         <rdfs:label xml:lang="en">valence carbon connectivity index (order 1)</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
         <dc:description>Descriptor that calculates carbon valence connectivity index (order 1). </dc:description>
-        <short_name>chi1vC</short_name>
+        <cheminf1:short_name>chi1vC</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001540 -->
+    <!-- distance to atom -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001540">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001540">
         <rdfs:label xml:lang="en">distance to atom</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000093"/>
-        <short_name>distanceToAtom</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000093"/>
         <dc:description>Descriptor that calculates the 3D distance between two atoms.</dc:description>
+        <cheminf1:short_name>distanceToAtom</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001541 -->
+    <!-- effective polarizability -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001541">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001541">
         <rdfs:label xml:lang="en">effective polarizability</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
         <rdfs:comment>EffectiveAtomPolarizabilityDescriptor, effAtomPol</rdfs:comment>
-        <short_name>effectivePolarizability</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates the effective polarizability of a given heavy atom.</dc:description>
+        <cheminf1:short_name>effectivePolarizability</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001542 -->
+    <!-- hybridization ratio -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001542">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001542">
         <rdfs:label xml:lang="en">hybridization ratio</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <dc:description>Characterizes molecular complexity in terms of carbon hybridization states.</dc:description>
         <rdfs:comment>It reports the fraction of sp3 carbons to sp2 carbons as Nsp3/ (Nsp3 + Nsp2). The original form of the descriptor (i.e., simple ratio) has been used to characterize molecular complexity, especially in the are of natural products , which usually have a high value of the sp3 to sp2 ratio. Other short names: HybridizationRatio, HybRatio.</rdfs:comment>
-        <short_name>hybratio</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Characterizes molecular complexity in terms of carbon hybridization states.</dc:description>
+        <cheminf1:short_name>hybratio</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001543 -->
+    <!-- Kier and Hall kappa molecular shape indices -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001543">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001543">
         <rdfs:label xml:lang="en">Kier and Hall kappa molecular shape indices</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000092"/>
-        <dc:description>Descriptor that calculates Kier and Hall kappa molecular shape indices.</dc:description>
-        <short_name>kierValues</short_name>
         <rdfs:comment>Kier and Hall kappa molecular shape indices compare the molecular graph with minimal and maximal molecular graphs. First kappa shape index is given by n ( n - 1 ) 2 m 2 , second kappa shape index is given by ( n - 1 ) ( n - 2 ) 2 p 2 2 and third kappa shape index is given by ( n - 1 ) ( n - 3 ) 2 p 3 2 for odd n and ( n - 3 ) ( n - 2 ) 2 p 3 2 for enev n, where n denotes the number of atoms in the hydrogen suppressed graph, m is the number of bonds in the hydrogen suppressed graph. Also, let p2 denote the number of paths of length 2 and let p3 denote the number of paths of length 3. Other short names: KappaShapeIndices, Kier1, Kier2, Kier3.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000092"/>
+        <dc:description>Descriptor that calculates Kier and Hall kappa molecular shape indices.</dc:description>
+        <cheminf1:short_name>kierValues</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001544 -->
+    <!-- partial pi charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001544">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001544">
         <rdfs:label xml:lang="en">partial pi charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1002/ange.19850970818</bibo:doi>
-        <dc:description>Descriptor that calculates pi partial charges in pi-bonded systems of an heavy atom based on based on Gasteiger H.Saller (PEPE).</dc:description>
-        <short_name>partialPiCharge</short_name>
         <rdfs:comment>Other short_name: pepe.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
+        <dc:description>Descriptor that calculates pi partial charges in pi-bonded systems of an heavy atom based on based on Gasteiger H.Saller (PEPE).</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1002/ange.19850970818</bibo:doi>
+        <cheminf1:short_name>partialPiCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001545 -->
+    <!-- partial sigma charge -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001545">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001545">
         <rdfs:label xml:lang="en">partial sigma charge</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <bibo:doi rdf:datatype="&xsd;string">http://dx.doi.org/10.1016/0040-4020(80)80168-2</bibo:doi>
-        <short_name>partialSigmaCharge</short_name>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
         <dc:description>Descriptor that calculates sigma partial charges in sigma-bonded systems (PEOE) of an heavy atom based on Gasteiger Marsili.</dc:description>
+        <bibo:doi rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://dx.doi.org/10.1016/0040-4020(80)80168-2</bibo:doi>
+        <cheminf1:short_name>partialSigmaCharge</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://semanticscience.org/resource/CHEMINF_001546 -->
+    <!-- pi electronegativity -->
 
-    <owl:Class rdf:about="&resource;CHEMINF_001546">
+    <owl:Class rdf:about="http://semanticscience.org/resource/CHEMINF_001546">
         <rdfs:label xml:lang="en">pi electronegativity</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000087"/>
-        <dc:description>Descriptor that returns the pi electronegativity for a given atom.</dc:description>
-        <short_name>piElectronegativity</short_name>
         <rdfs:comment>Pi electronegativity is given by X = a + b q + c ( q 2 ) , where a, b and c are Gasteiger Marsili parameters, and q is the sigma charge. Other short_name: elecPiA.</rdfs:comment>
+        <rdfs:subClassOf rdf:resource="http://semanticscience.org/resource/CHEMINF_000087"/>
+        <dc:description>Descriptor that returns the pi electronegativity for a given atom.</dc:description>
+        <cheminf1:short_name>piElectronegativity</cheminf1:short_name>
     </owl:Class>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Disposition -->
+    <!-- process -->
 
-    <owl:Class rdf:about="&snap;Disposition"/>
+    <owl:Class rdf:about="http://www.ifomis.org/bfo/1.1/span#Process"/>
     
 
 
-    <!-- http://www.ifomis.org/bfo/1.1/snap#MaterialEntity -->
+    <!-- Thing -->
 
-    <owl:Class rdf:about="&snap;MaterialEntity"/>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#Quality -->
-
-    <owl:Class rdf:about="&snap;Quality"/>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/snap#SpecificallyDependentContinuant -->
-
-    <owl:Class rdf:about="&snap;SpecificallyDependentContinuant"/>
-    
-
-
-    <!-- http://www.ifomis.org/bfo/1.1/span#Process -->
-
-    <owl:Class rdf:about="&span;Process"/>
-    
-
-
-    <!-- http://www.w3.org/2002/07/owl#Thing -->
-
-    <owl:Class rdf:about="&owl;Thing"/>
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
     
 
 
@@ -5307,13 +6464,10 @@ where p is the partial pressure of the solute in the gas above the solution, c i
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <rdf:Description rdf:about="&obo;IAO_0000101">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000054">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000100">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;integral_part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000062">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -5336,28 +6490,418 @@ where p is the partial pressure of the solute in the gas above the solution, c i
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000105">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/GAZ"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000314">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000001">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000315">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000003">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000312">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000005">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000313">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000006">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000311">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000007">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000309">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000008">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&ro;transformation_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000009">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000012">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000013">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000015">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000017">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000018">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000019">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000024">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000025">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000032">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000034">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000035">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000037">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000038">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000047">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000055">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000057">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000059">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000065">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000078">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000079">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000088">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000091">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000093">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000096">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000097">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000002"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000100">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000101">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000105">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000128">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000121"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000129">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000131">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000132">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000135">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000140">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000141">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000142">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000144">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000178">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000179">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000180">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000181">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000182">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000183">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000184">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000185">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000186">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000220">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000222">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000223">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000225">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000301">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000302">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000303">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000304">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000305">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000306">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000307">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000308">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000309">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000311">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000312">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000313">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000314">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000315">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000316">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000317">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000318">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000319">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000320">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000321">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000322">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000323">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000324">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000325">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000326">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000327">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000328">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000329">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000330">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000400">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000401">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000402">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000403">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000124"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000408">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000413">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000414">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000415">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000416">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000417">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000418">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000419">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000442">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000443">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000572">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000573">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000574">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000575">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000576">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000580">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000581">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000582">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000583">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000584">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000066">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000283">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000230"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000471">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000122">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000125">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001000">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasExactSynonym>
+            <rdf:Description/>
+        </oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>
+            <rdf:Description/>
+        </oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>
+            <rdf:Description/>
+        </oboInOwl:hasExactSynonym>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001018">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -5380,59 +6924,7 @@ where p is the partial pressure of the solute in the gas above the solution, c i
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000308">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000307">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;GAZ_00000448">
-        <obo:IAO_0000412 rdf:resource="&obo;GAZ"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000306">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000305">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000180">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000182">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000181">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000184">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000183">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000047">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000186">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000185">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000111">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000583">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000112">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000584">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;proper_part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001025">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -5455,19 +6947,7 @@ where p is the partial pressure of the solute in the gas above the solution, c i
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000589">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000116">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000301">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000302">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;improper_part_of">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002220">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -5490,479 +6970,93 @@ where p is the partial pressure of the solute in the gas above the solution, c i
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000303">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002494">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;iao/obsolete.owl">
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000001">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000002">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000003">
+        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/iao/iao-main.owl">
         <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000304">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/iao/obsolete.owl">
+        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000442">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000581">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000582">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000443">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000580">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000059">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000057">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000055">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000576">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000572">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000573">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000574">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000575">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;publisher">
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/coverage">
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000065">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/creator">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000283">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000230"/>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/date">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
     </rdf:Description>
-    <rdf:Description rdf:about="&resource;CHEMINF_000064">
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/identifier">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/publisher">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/relation">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/source">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/subject">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.org/dc/elements/1.1/type">
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000064">
         <rdfs:comment>NOTE: QSAR descriptors are often just called &apos;chemical descriptor&apos; or &apos;molecular descriptor&apos; in the cheminformatics community.</rdfs:comment>
         <oboInOwl:hasAlternativeId>BODO:Descriptor</oboInOwl:hasAlternativeId>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000471">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000189">
+        <obo:IAO_0000115>A descriptor characterizing the ratio of the length to the breadth of a given entity.</obo:IAO_0000115>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;creator">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000179">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000178">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000079">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;date">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000078">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;located_in">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000006">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000007">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000005">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000141">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000003">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;relationship">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000142">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000001">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000140">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000144">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;preceded_by">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;source">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000088">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000401">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000400">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000403">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000402">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000015">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&resource;CHEMINF_000191">
-        <obo:IAO_0000118>ionization energy</obo:IAO_0000118>
-        <obo:IAO_0000118>ionization enthalpy</obo:IAO_0000118>
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000191">
         <obo:IAO_0000115>An ionization energy descriptor is a descriptor that describes the minimum amount of energy required to remove an electron (to an infinite distance) from an atom or molecule in a gaseous state. 
 
 X + energy → X+ + e-
 
 The term &apos;ionization potential&apos; has historically been used but is now no longer recommended. </obo:IAO_0000115>
+        <obo:IAO_0000118>ionization energy</obo:IAO_0000118>
+        <obo:IAO_0000118>ionization enthalpy</obo:IAO_0000118>
         <obo:IAO_0000118>ionization potential</obo:IAO_0000118>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000017">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0500000">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000018">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000226"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000012">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000013">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;identifier">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000066">
-        <obo:IAO_0000412 rdf:resource="&obo;obi.owl"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000408">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;subject">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000414">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000413">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000097">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000003">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&resource;CHEMINF_000189">
-        <obo:IAO_0000115>A descriptor characterizing the ratio of the length to the breadth of a given entity.</obo:IAO_0000115>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000001">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000096">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;UO_0000002">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/UO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000009">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000093">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000008">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000091">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000024">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000025">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;contained_in">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;PATO_0000125">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000419">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000128">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000121"/>
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000226"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000415">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000318">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000319">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000416">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000123"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000316">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;derives_from">
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasExactSynonym>
-            <rdf:Description/>
-        </oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>
-            <rdf:Description/>
-        </oboInOwl:hasExactSynonym>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-        <oboInOwl:hasExactSynonym>
-            <rdf:Description/>
-        </oboInOwl:hasExactSynonym>
-        <oboInOwl:hasDefinition>
-            <rdf:Description>
-                <oboInOwl:hasDbXref>
-                    <rdf:Description/>
-                </oboInOwl:hasDbXref>
-            </rdf:Description>
-        </oboInOwl:hasDefinition>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000417">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000418">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000317">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000326">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000325">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000324">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000323">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000322">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000321">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000119">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000320">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;type">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000223">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000222">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;PATO_0000122">
-        <obo:IAO_0000412 rdf:resource="http://purl.org/obo/owl/PATO"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000220">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000019">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000225">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000034">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000035">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000131">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000037">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000002"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000038">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;OBI_0000300">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000327">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000132">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000328">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000329">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000032">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000135">
-        <obo:IAO_0000231 rdf:resource="&obo;IAO_0000103"/>
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0100001">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000125"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&dc;coverage">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000330">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000120"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000129">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000124"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&resource;CHEMINF_000241">
+    <rdf:Description rdf:about="http://semanticscience.org/resource/CHEMINF_000241">
         <obo:IAO_0000118>enthalpy of formation</obo:IAO_0000118>
         <obo:IAO_0000118>heat of formation</obo:IAO_0000118>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;IAO_0000232">
-        <obo:IAO_0000114 rdf:resource="&obo;IAO_0000122"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="&ro;adjacent_to">
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#improper_part_of">
         <oboInOwl:hasDefinition>
             <rdf:Description>
                 <oboInOwl:hasDbXref>
@@ -5985,15 +7079,78 @@ The term &apos;ionization potential&apos; has historically been used but is now 
             </rdf:Description>
         </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&obo;iao/iao-main.owl">
-        <rdfs:seeAlso rdf:resource="http://code.google.com/p/information-artifact-ontology/"/>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#integral_part_of">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
     </rdf:Description>
-    <rdf:Description rdf:about="&dc;relation">
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/elements/1.1/"/>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#proper_part_of">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://www.obofoundry.org/ro/ro.owl#relationship">
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>
+            <rdf:Description>
+                <oboInOwl:hasDbXref>
+                    <rdf:Description/>
+                </oboInOwl:hasDbXref>
+            </rdf:Description>
+        </oboInOwl:hasDefinition>
     </rdf:Description>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.0) http://owlapi.sourceforge.net -->
 

--- a/ontology/cheminf.owl
+++ b/ontology/cheminf.owl
@@ -3682,6 +3682,12 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     </rdf:Description>
     
 
+    <!-- http://semanticscience.org/resource/CHEMINF_000567 -->
+
+    <rdf:Description rdf:about="&resource;CHEMINF_000567">
+        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
+    </rdf:Description>
+
 
     <!-- http://semanticscience.org/resource/CHEMINF_000411 -->
 

--- a/ontology/cheminf.owl
+++ b/ontology/cheminf.owl
@@ -3678,7 +3678,7 @@ Zwitterion (ZW)	ACD_MOST_ApKa &lt;6.5 and ACD_MOST_BpKa&gt;8.5
     <!-- http://semanticscience.org/resource/CHEMINF_000410 -->
 
     <rdf:Description rdf:about="&resource;CHEMINF_000410">
-        <rdfs:subClassOf rdf:resource="&resource;CHEMINF_000464"/>
+        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
     </rdf:Description>
     
 


### PR DESCRIPTION
…e default mapping file and header cleanup enabled.

The online version of BFOConvert at http://ontobull.hegroup.org/bfoconvert was used. Each file in the ontology directory was run through BFOConvert with the default IRI Mapping file and the optional header cleanup file feature enabled. The output cheminf.owl was then opened in Stanford Protege Desktop for a cursory examination.

This change should address Issue #19 
